### PR TITLE
ecpprog branch is now 'main'

### DIFF
--- a/default/rules/programmers.py
+++ b/default/rules/programmers.py
@@ -38,7 +38,7 @@ SourceLocation(
 	name = 'ecpprog',
 	vcs = 'git',
 	location = 'https://github.com/gregdavill/ecpprog',
-	revision = 'origin/master'
+	revision = 'origin/main'
 )
 
 Target(


### PR DESCRIPTION
It looks like [ecpprog](https://github.com/gregdavill/ecpprog) `master` must have been renamed at some point. @gregdavill ?