### PR TITLE
Add GHDL_PREFIX to bin/yosys

### DIFF
--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -55,7 +55,8 @@ sed -i -re 's|^flag:VVP_EXECUTABLE=.*$|flag:VVP_EXECUTABLE='\$release_topdir_abs
 sed -i -re 's|^flag:VVP_EXECUTABLE=.*$|flag:VVP_EXECUTABLE='\$release_topdir_abs'/bin/vvp|g' \$release_topdir_abs/lib/ivl/vvp-s.conf
 EOT
         fi
-        if [ ! -z "$(strings libexec/$(basename $binfile) | grep ghdl)" ]; then
+        # yosys ghdl plugin requires GHDL_PREFIX too
+        if [ ! -z "$(strings libexec/$(basename $binfile) | grep ghdl)" ] || [ $binfile == "bin/yosys" ]; then
             cat >> $binfile << EOT
 export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
 EOT


### PR DESCRIPTION
With yosys-ghdl-plugin built as a library it doesn't get detected
with `strings`, so instead we can enable GHDL_PREFIX explicitly.

Note that I haven't tested this build locally.