### PR TITLE
Windows Python3 SSL Library Fix

### DIFF
--- a/default/scripts/system-resources.sh
+++ b/default/scripts/system-resources.sh
@@ -112,4 +112,8 @@ if [ ${ARCH_BASE} == 'windows' ]; then
     rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/icons/Adwaita/256x256
     rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/icons/Adwaita/512x512
     rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/icons/Adwaita/cursors
+
+    # Python3 ssl libary fixes
+    cp ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libcrypto-1_1-x64.dll ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/python3.8/lib-dynload/libcrypto-1_1-x64.dll
+    cp ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libssl-1_1-x64.dll  ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/python3.8/lib-dynload/libssl-1_1-x64.dll 
 fi


### PR DESCRIPTION
Fix for issue #23 - Python3 for Windows does not package SSL library properly

The `ssl` python library (which is a wrapper for the `_ssl` library) uses the `libcrypto-1_1-x64.dll` and `libssl-1_1-x64.dll` DLLs. These DLLs are located in `lib/`, where Python can't find them:
```
  File "D:\a\github-actions-scratch\github-actions-scratch\oss-cad-suite\lib\python3.8\ssl.py", line 98, in <module>
    import _ssl             # if we can't import it, let the error propagate
ImportError: DLL load failed while importing _ssl: The specified procedure could not be found.
```
 This fix copies them into `lib/python3.8/lib-dynload/` where they are in python path and can be found.

I would guess that this has not previously caused issues due to the DLLs being found elsewhere in the user's system. However this cannot be relied upon, and notably breaks in Windows Github Actions runners.