### PR TITLE
Add cocotb

### DIFF
--- a/.github/workflows/darwin-x64.yml
+++ b/.github/workflows/darwin-x64.yml
@@ -1475,6 +1475,43 @@ jobs:
           tag: bucket-darwin-x64
           artifacts: "darwin-x64-pyhdl.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  darwin-x64-cocotb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: darwin-x64-python3
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v2
+        with:
+          path: _sources
+          key: cache-sources-cocotb
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-cocotb.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download darwin-x64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-python3.tgz" | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=darwin-x64 --target=cocotb --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('darwin-x64-cocotb.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-darwin-x64
+          artifacts: "darwin-x64-cocotb.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   darwin-x64-system-resources:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1511,7 +1548,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   darwin-x64-default:
     runs-on: ubuntu-latest
-    needs: [ darwin-x64-aiger, darwin-x64-avy, darwin-x64-bitwuzla, darwin-x64-boolector, darwin-x64-dfu-util, darwin-x64-ecpdap, darwin-x64-ecpprog, darwin-x64-flask, darwin-x64-fujprog, darwin-x64-graphviz, darwin-x64-gtkwave, darwin-x64-icesprog, darwin-x64-icestorm, darwin-x64-iverilog, darwin-x64-mcy, darwin-x64-nextpnr-ecp5, darwin-x64-nextpnr-generic, darwin-x64-nextpnr-ice40, darwin-x64-nextpnr-machxo2, darwin-x64-nextpnr-nexus, darwin-x64-openfpgaloader, darwin-x64-openocd, darwin-x64-pono, darwin-x64-prjoxide, darwin-x64-prjtrellis, darwin-x64-pyhdl, darwin-x64-python-programmers, darwin-x64-python3, darwin-x64-sby, darwin-x64-sby-gui, darwin-x64-system-resources, darwin-x64-utils, darwin-x64-verilator, darwin-x64-xdot, darwin-x64-yices, darwin-x64-yosys, darwin-x64-z3 ]
+    needs: [ darwin-x64-aiger, darwin-x64-avy, darwin-x64-bitwuzla, darwin-x64-boolector, darwin-x64-cocotb, darwin-x64-dfu-util, darwin-x64-ecpdap, darwin-x64-ecpprog, darwin-x64-flask, darwin-x64-fujprog, darwin-x64-graphviz, darwin-x64-gtkwave, darwin-x64-icesprog, darwin-x64-icestorm, darwin-x64-iverilog, darwin-x64-mcy, darwin-x64-nextpnr-ecp5, darwin-x64-nextpnr-generic, darwin-x64-nextpnr-ice40, darwin-x64-nextpnr-machxo2, darwin-x64-nextpnr-nexus, darwin-x64-openfpgaloader, darwin-x64-openocd, darwin-x64-pono, darwin-x64-prjoxide, darwin-x64-prjtrellis, darwin-x64-pyhdl, darwin-x64-python-programmers, darwin-x64-python3, darwin-x64-sby, darwin-x64-sby-gui, darwin-x64-system-resources, darwin-x64-utils, darwin-x64-verilator, darwin-x64-xdot, darwin-x64-yices, darwin-x64-yosys, darwin-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1527,6 +1564,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-bitwuzla.tgz" | tar xvfz -
       - name: Download darwin-x64-boolector
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-boolector.tgz" | tar xvfz -
+      - name: Download darwin-x64-cocotb
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-cocotb.tgz" | tar xvfz -
       - name: Download darwin-x64-dfu-util
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-dfu-util.tgz" | tar xvfz -
       - name: Download darwin-x64-ecpdap

--- a/.github/workflows/linux-arm.yml
+++ b/.github/workflows/linux-arm.yml
@@ -1546,6 +1546,43 @@ jobs:
           tag: bucket-linux-arm
           artifacts: "linux-arm-pyhdl.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  linux-arm-cocotb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: linux-arm-python3
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v2
+        with:
+          path: _sources
+          key: cache-sources-cocotb
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm/linux-arm-cocotb.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-arm-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm/linux-arm-python3.tgz" | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-arm --target=cocotb --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-arm-cocotb.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-arm
+          artifacts: "linux-arm-cocotb.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   linux-arm-system-resources:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1582,7 +1619,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-arm-default:
     runs-on: ubuntu-latest
-    needs: [ linux-arm-aiger, linux-arm-avy, linux-arm-bitwuzla, linux-arm-boolector, linux-arm-dfu-util, linux-arm-ecpdap, linux-arm-ecpprog, linux-arm-flask, linux-arm-fujprog, linux-arm-graphviz, linux-arm-gtkwave, linux-arm-icesprog, linux-arm-icestorm, linux-arm-iverilog, linux-arm-mcy, linux-arm-nextpnr-ecp5, linux-arm-nextpnr-generic, linux-arm-nextpnr-ice40, linux-arm-nextpnr-machxo2, linux-arm-nextpnr-nexus, linux-arm-openfpgaloader, linux-arm-openocd, linux-arm-pono, linux-arm-prjoxide, linux-arm-prjtrellis, linux-arm-pyhdl, linux-arm-python-programmers, linux-arm-python2, linux-arm-python3, linux-arm-sby, linux-arm-sby-gui, linux-arm-suprove, linux-arm-system-resources, linux-arm-utils, linux-arm-verilator, linux-arm-xdot, linux-arm-yices, linux-arm-yosys, linux-arm-z3 ]
+    needs: [ linux-arm-aiger, linux-arm-avy, linux-arm-bitwuzla, linux-arm-boolector, linux-arm-cocotb, linux-arm-dfu-util, linux-arm-ecpdap, linux-arm-ecpprog, linux-arm-flask, linux-arm-fujprog, linux-arm-graphviz, linux-arm-gtkwave, linux-arm-icesprog, linux-arm-icestorm, linux-arm-iverilog, linux-arm-mcy, linux-arm-nextpnr-ecp5, linux-arm-nextpnr-generic, linux-arm-nextpnr-ice40, linux-arm-nextpnr-machxo2, linux-arm-nextpnr-nexus, linux-arm-openfpgaloader, linux-arm-openocd, linux-arm-pono, linux-arm-prjoxide, linux-arm-prjtrellis, linux-arm-pyhdl, linux-arm-python-programmers, linux-arm-python2, linux-arm-python3, linux-arm-sby, linux-arm-sby-gui, linux-arm-suprove, linux-arm-system-resources, linux-arm-utils, linux-arm-verilator, linux-arm-xdot, linux-arm-yices, linux-arm-yosys, linux-arm-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1598,6 +1635,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm/linux-arm-bitwuzla.tgz" | tar xvfz -
       - name: Download linux-arm-boolector
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm/linux-arm-boolector.tgz" | tar xvfz -
+      - name: Download linux-arm-cocotb
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm/linux-arm-cocotb.tgz" | tar xvfz -
       - name: Download linux-arm-dfu-util
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm/linux-arm-dfu-util.tgz" | tar xvfz -
       - name: Download linux-arm-ecpdap

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -1546,6 +1546,43 @@ jobs:
           tag: bucket-linux-arm64
           artifacts: "linux-arm64-pyhdl.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  linux-arm64-cocotb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: linux-arm64-python3
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v2
+        with:
+          path: _sources
+          key: cache-sources-cocotb
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-cocotb.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-arm64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-python3.tgz" | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-arm64 --target=cocotb --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-arm64-cocotb.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-arm64
+          artifacts: "linux-arm64-cocotb.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   linux-arm64-system-resources:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1582,7 +1619,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-arm64-default:
     runs-on: ubuntu-latest
-    needs: [ linux-arm64-aiger, linux-arm64-avy, linux-arm64-bitwuzla, linux-arm64-boolector, linux-arm64-dfu-util, linux-arm64-ecpdap, linux-arm64-ecpprog, linux-arm64-flask, linux-arm64-fujprog, linux-arm64-graphviz, linux-arm64-gtkwave, linux-arm64-icesprog, linux-arm64-icestorm, linux-arm64-iverilog, linux-arm64-mcy, linux-arm64-nextpnr-ecp5, linux-arm64-nextpnr-generic, linux-arm64-nextpnr-ice40, linux-arm64-nextpnr-machxo2, linux-arm64-nextpnr-nexus, linux-arm64-openfpgaloader, linux-arm64-openocd, linux-arm64-pono, linux-arm64-prjoxide, linux-arm64-prjtrellis, linux-arm64-pyhdl, linux-arm64-python-programmers, linux-arm64-python2, linux-arm64-python3, linux-arm64-sby, linux-arm64-sby-gui, linux-arm64-suprove, linux-arm64-system-resources, linux-arm64-utils, linux-arm64-verilator, linux-arm64-xdot, linux-arm64-yices, linux-arm64-yosys, linux-arm64-z3 ]
+    needs: [ linux-arm64-aiger, linux-arm64-avy, linux-arm64-bitwuzla, linux-arm64-boolector, linux-arm64-cocotb, linux-arm64-dfu-util, linux-arm64-ecpdap, linux-arm64-ecpprog, linux-arm64-flask, linux-arm64-fujprog, linux-arm64-graphviz, linux-arm64-gtkwave, linux-arm64-icesprog, linux-arm64-icestorm, linux-arm64-iverilog, linux-arm64-mcy, linux-arm64-nextpnr-ecp5, linux-arm64-nextpnr-generic, linux-arm64-nextpnr-ice40, linux-arm64-nextpnr-machxo2, linux-arm64-nextpnr-nexus, linux-arm64-openfpgaloader, linux-arm64-openocd, linux-arm64-pono, linux-arm64-prjoxide, linux-arm64-prjtrellis, linux-arm64-pyhdl, linux-arm64-python-programmers, linux-arm64-python2, linux-arm64-python3, linux-arm64-sby, linux-arm64-sby-gui, linux-arm64-suprove, linux-arm64-system-resources, linux-arm64-utils, linux-arm64-verilator, linux-arm64-xdot, linux-arm64-yices, linux-arm64-yosys, linux-arm64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1598,6 +1635,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-bitwuzla.tgz" | tar xvfz -
       - name: Download linux-arm64-boolector
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-boolector.tgz" | tar xvfz -
+      - name: Download linux-arm64-cocotb
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-cocotb.tgz" | tar xvfz -
       - name: Download linux-arm64-dfu-util
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-dfu-util.tgz" | tar xvfz -
       - name: Download linux-arm64-ecpdap

--- a/.github/workflows/linux-riscv64.yml
+++ b/.github/workflows/linux-riscv64.yml
@@ -1546,6 +1546,43 @@ jobs:
           tag: bucket-linux-riscv64
           artifacts: "linux-riscv64-pyhdl.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  linux-riscv64-cocotb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: linux-riscv64-python3
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v2
+        with:
+          path: _sources
+          key: cache-sources-cocotb
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-riscv64/linux-riscv64-cocotb.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-riscv64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-riscv64/linux-riscv64-python3.tgz" | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-riscv64 --target=cocotb --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-riscv64-cocotb.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-riscv64
+          artifacts: "linux-riscv64-cocotb.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   linux-riscv64-system-resources:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1582,7 +1619,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-riscv64-default:
     runs-on: ubuntu-latest
-    needs: [ linux-riscv64-aiger, linux-riscv64-avy, linux-riscv64-bitwuzla, linux-riscv64-boolector, linux-riscv64-dfu-util, linux-riscv64-ecpdap, linux-riscv64-ecpprog, linux-riscv64-flask, linux-riscv64-fujprog, linux-riscv64-graphviz, linux-riscv64-gtkwave, linux-riscv64-icesprog, linux-riscv64-icestorm, linux-riscv64-iverilog, linux-riscv64-mcy, linux-riscv64-nextpnr-ecp5, linux-riscv64-nextpnr-generic, linux-riscv64-nextpnr-ice40, linux-riscv64-nextpnr-machxo2, linux-riscv64-nextpnr-nexus, linux-riscv64-openfpgaloader, linux-riscv64-openocd, linux-riscv64-pono, linux-riscv64-prjoxide, linux-riscv64-prjtrellis, linux-riscv64-pyhdl, linux-riscv64-python-programmers, linux-riscv64-python2, linux-riscv64-python3, linux-riscv64-sby, linux-riscv64-sby-gui, linux-riscv64-suprove, linux-riscv64-system-resources, linux-riscv64-utils, linux-riscv64-verilator, linux-riscv64-xdot, linux-riscv64-yices, linux-riscv64-yosys, linux-riscv64-z3 ]
+    needs: [ linux-riscv64-aiger, linux-riscv64-avy, linux-riscv64-bitwuzla, linux-riscv64-boolector, linux-riscv64-cocotb, linux-riscv64-dfu-util, linux-riscv64-ecpdap, linux-riscv64-ecpprog, linux-riscv64-flask, linux-riscv64-fujprog, linux-riscv64-graphviz, linux-riscv64-gtkwave, linux-riscv64-icesprog, linux-riscv64-icestorm, linux-riscv64-iverilog, linux-riscv64-mcy, linux-riscv64-nextpnr-ecp5, linux-riscv64-nextpnr-generic, linux-riscv64-nextpnr-ice40, linux-riscv64-nextpnr-machxo2, linux-riscv64-nextpnr-nexus, linux-riscv64-openfpgaloader, linux-riscv64-openocd, linux-riscv64-pono, linux-riscv64-prjoxide, linux-riscv64-prjtrellis, linux-riscv64-pyhdl, linux-riscv64-python-programmers, linux-riscv64-python2, linux-riscv64-python3, linux-riscv64-sby, linux-riscv64-sby-gui, linux-riscv64-suprove, linux-riscv64-system-resources, linux-riscv64-utils, linux-riscv64-verilator, linux-riscv64-xdot, linux-riscv64-yices, linux-riscv64-yosys, linux-riscv64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1598,6 +1635,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-riscv64/linux-riscv64-bitwuzla.tgz" | tar xvfz -
       - name: Download linux-riscv64-boolector
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-riscv64/linux-riscv64-boolector.tgz" | tar xvfz -
+      - name: Download linux-riscv64-cocotb
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-riscv64/linux-riscv64-cocotb.tgz" | tar xvfz -
       - name: Download linux-riscv64-dfu-util
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-riscv64/linux-riscv64-dfu-util.tgz" | tar xvfz -
       - name: Download linux-riscv64-ecpdap

--- a/.github/workflows/linux-x64.yml
+++ b/.github/workflows/linux-x64.yml
@@ -1793,6 +1793,43 @@ jobs:
           tag: bucket-linux-x64
           artifacts: "linux-x64-pyhdl.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  linux-x64-cocotb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: linux-x64-python3
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v2
+        with:
+          path: _sources
+          key: cache-sources-cocotb
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-cocotb.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-x64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3.tgz" | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-x64 --target=cocotb --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-x64-cocotb.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-x64
+          artifacts: "linux-x64-cocotb.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-system-resources:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1829,7 +1866,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-default:
     runs-on: ubuntu-latest
-    needs: [ linux-x64-aiger, linux-x64-avy, linux-x64-bitwuzla, linux-x64-boolector, linux-x64-dfu-util, linux-x64-ecpdap, linux-x64-ecpprog, linux-x64-flask, linux-x64-fujprog, linux-x64-ghdl, linux-x64-ghdl-yosys-plugin, linux-x64-graphviz, linux-x64-gtkwave, linux-x64-icesprog, linux-x64-icestorm, linux-x64-iverilog, linux-x64-mcy, linux-x64-nextpnr-ecp5, linux-x64-nextpnr-generic, linux-x64-nextpnr-ice40, linux-x64-nextpnr-machxo2, linux-x64-nextpnr-nexus, linux-x64-openfpgaloader, linux-x64-openocd, linux-x64-pono, linux-x64-prjoxide, linux-x64-prjtrellis, linux-x64-pyhdl, linux-x64-python-programmers, linux-x64-python2, linux-x64-python3, linux-x64-sby, linux-x64-sby-gui, linux-x64-suprove, linux-x64-system-resources, linux-x64-utils, linux-x64-verilator, linux-x64-xdot, linux-x64-yices, linux-x64-yosys, linux-x64-z3 ]
+    needs: [ linux-x64-aiger, linux-x64-avy, linux-x64-bitwuzla, linux-x64-boolector, linux-x64-cocotb, linux-x64-dfu-util, linux-x64-ecpdap, linux-x64-ecpprog, linux-x64-flask, linux-x64-fujprog, linux-x64-ghdl, linux-x64-ghdl-yosys-plugin, linux-x64-graphviz, linux-x64-gtkwave, linux-x64-icesprog, linux-x64-icestorm, linux-x64-iverilog, linux-x64-mcy, linux-x64-nextpnr-ecp5, linux-x64-nextpnr-generic, linux-x64-nextpnr-ice40, linux-x64-nextpnr-machxo2, linux-x64-nextpnr-nexus, linux-x64-openfpgaloader, linux-x64-openocd, linux-x64-pono, linux-x64-prjoxide, linux-x64-prjtrellis, linux-x64-pyhdl, linux-x64-python-programmers, linux-x64-python2, linux-x64-python3, linux-x64-sby, linux-x64-sby-gui, linux-x64-suprove, linux-x64-system-resources, linux-x64-utils, linux-x64-verilator, linux-x64-xdot, linux-x64-yices, linux-x64-yosys, linux-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1845,6 +1882,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-bitwuzla.tgz" | tar xvfz -
       - name: Download linux-x64-boolector
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-boolector.tgz" | tar xvfz -
+      - name: Download linux-x64-cocotb
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-cocotb.tgz" | tar xvfz -
       - name: Download linux-x64-dfu-util
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-dfu-util.tgz" | tar xvfz -
       - name: Download linux-x64-ecpdap

--- a/.github/workflows/windows-x64.yml
+++ b/.github/workflows/windows-x64.yml
@@ -1370,6 +1370,43 @@ jobs:
           tag: bucket-windows-x64
           artifacts: "windows-x64-pyhdl.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  windows-x64-cocotb:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: windows-x64-python3
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v2
+        with:
+          path: _sources
+          key: cache-sources-cocotb
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-cocotb.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download windows-x64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-python3.tgz" | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=windows-x64 --target=cocotb --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('windows-x64-cocotb.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-windows-x64
+          artifacts: "windows-x64-cocotb.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   windows-x64-system-resources:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1406,7 +1443,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   windows-x64-default:
     runs-on: ubuntu-latest
-    needs: [ windows-x64-avy, windows-x64-bitwuzla, windows-x64-boolector, windows-x64-dfu-util, windows-x64-ecpdap, windows-x64-ecpprog, windows-x64-flask, windows-x64-fujprog, windows-x64-gtkwave, windows-x64-icesprog, windows-x64-icestorm, windows-x64-iverilog, windows-x64-mcy, windows-x64-nextpnr-ecp5, windows-x64-nextpnr-generic, windows-x64-nextpnr-ice40, windows-x64-nextpnr-machxo2, windows-x64-nextpnr-nexus, windows-x64-openfpgaloader, windows-x64-openocd, windows-x64-pono, windows-x64-prjoxide, windows-x64-prjtrellis, windows-x64-pyhdl, windows-x64-python-programmers, windows-x64-python3, windows-x64-sby, windows-x64-sby-gui, windows-x64-system-resources, windows-x64-utils, windows-x64-verilator, windows-x64-yices, windows-x64-yosys, windows-x64-z3 ]
+    needs: [ windows-x64-avy, windows-x64-bitwuzla, windows-x64-boolector, windows-x64-cocotb, windows-x64-dfu-util, windows-x64-ecpdap, windows-x64-ecpprog, windows-x64-flask, windows-x64-fujprog, windows-x64-gtkwave, windows-x64-icesprog, windows-x64-icestorm, windows-x64-iverilog, windows-x64-mcy, windows-x64-nextpnr-ecp5, windows-x64-nextpnr-generic, windows-x64-nextpnr-ice40, windows-x64-nextpnr-machxo2, windows-x64-nextpnr-nexus, windows-x64-openfpgaloader, windows-x64-openocd, windows-x64-pono, windows-x64-prjoxide, windows-x64-prjtrellis, windows-x64-pyhdl, windows-x64-python-programmers, windows-x64-python3, windows-x64-sby, windows-x64-sby-gui, windows-x64-system-resources, windows-x64-utils, windows-x64-verilator, windows-x64-yices, windows-x64-yosys, windows-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1420,6 +1457,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-bitwuzla.tgz" | tar xvfz -
       - name: Download windows-x64-boolector
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-boolector.tgz" | tar xvfz -
+      - name: Download windows-x64-cocotb
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-cocotb.tgz" | tar xvfz -
       - name: Download windows-x64-dfu-util
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-dfu-util.tgz" | tar xvfz -
       - name: Download windows-x64-ecpdap

--- a/default/rules/cocotb.py
+++ b/default/rules/cocotb.py
@@ -1,0 +1,9 @@
+from src.base import Target
+
+Target(
+	name = 'cocotb',
+	dependencies = [ 'python3' ],
+	resources = [ 'python3' ],
+	patches = [ 'python3_package.sh' ],
+	sources = [ ],
+)

--- a/default/rules/default.py
+++ b/default/rules/default.py
@@ -40,6 +40,7 @@ Target(
         'icesprog',
         'utils',
         'pyhdl',
+        'cocotb',
     ],
     branding = 'OSS CAD Suite',
     readme = 'README',

--- a/default/scripts/cocotb.sh
+++ b/default/scripts/cocotb.sh
@@ -1,0 +1,3 @@
+source ${PATCHES_DIR}/python3_package.sh
+python3_package_setup
+python3_package_pip_install "cocotb"


### PR DESCRIPTION
[cocotb](https://docs.cocotb.org/en/stable/) is a COroutine based COsimulation TestBench environment for verifying VHDL and SystemVerilog RTL using Python.

The reason why this needs to be included in the suite when it's "just a Python package" is that it builds a native component that, AFAIU, gets loaded into the simulator (e.g., `iverilog`) process. It cannot be installed by the user using the suite's pip, since the latter is not able to compile C/C++, and when built with the OS' native pip & GCC, there is a runtime conflict of libc[++] versions between the library and the simulator.

I have been able to build Cocotb with this patch, however testing it out is a bit trickier, since I suppose it requires building a substantial portion of the suite from source, which takes many hours on a slower CPU. (I haven't been able to use the CI in a fork)