### PR TITLE
added support for iceprogduino

### DIFF
--- a/default/rules/default.py
+++ b/default/rules/default.py
@@ -37,6 +37,7 @@ Target(
         'iverilog',
         'ecpdap',
         'fujprog',
+        'iceprogduino',
         'python-programmers',
         'openocd',
         'icesprog',

--- a/default/rules/programmers.py
+++ b/default/rules/programmers.py
@@ -65,6 +65,22 @@ Target(
 	package = 'programmers',
 )
 
+# iceprogduino
+
+SourceLocation(
+	name = 'iceprogduino',
+	vcs = 'git',
+	location = 'https://github.com/OLIMEX/iCE40HX1K-EVB',
+	revision = 'origin/master',
+	license_file = 'LICENSE',
+)
+
+Target(
+	name = 'iceprogduino',
+	sources = [ 'iceprogduino' ],
+	package = 'programmers',
+)
+
 # openfpgaloader
 
 SourceLocation(

--- a/default/scripts/iceprogduino.sh
+++ b/default/scripts/iceprogduino.sh
@@ -1,0 +1,8 @@
+mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}/bin/
+if [ ${ARCH} == 'windows-x64' ]; then
+	cp iceprogduino/windows/winiceprogduino/winiceprogduino.exe ${OUTPUT_DIR}${INSTALL_PREFIX}/bin/iceprogduino.exe
+else
+	cd iceprogduino/programmer/iceprogduino
+	make
+	cp iceprogduino${EXE} ${OUTPUT_DIR}${INSTALL_PREFIX}/bin/.
+fi


### PR DESCRIPTION
Hi there,
I tried to add support for iceprogduino, which is the programmer for the development boards from Olimex:
iCE40HX1K-EVB and iCE40HX8K-EVB.
I did run:
./builder.py build --target=iceprogduino --arch=linux-x64
./builder.py build --target=iceprogduino --arch=windows-x64
and it build successfully.