### PR TITLE
Fix wrapper script fonts config path: issue #66

### DIFF
--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -205,8 +205,8 @@ EOT
         fi
         if $is_using_fonts; then
             cat >> "${script}" <<EOT
-export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
+export FONTCONFIG_FILE="\$FONTCONFIG_PATH/fonts.conf"
 sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
 EOT
         fi


### PR DESCRIPTION
Hello,

I recently did a fresh installation of the toolchain on ubuntu 22.04. Also encountered issue #66.

I "eyeballed" the solution. Not sure how to verify the potential fix. I am happy to help with other potential fixes as well.

Thanks. 