### PR TITLE
Handle unset `${HOME}` gracefully

### DIFF
--- a/scripts/package-darwin.sh
+++ b/scripts/package-darwin.sh
@@ -78,10 +78,12 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export LC_ALL="C"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
-                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
-                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
-                mkdir -p "\$HOME/.config/yosyshq" "\$HOME/.local/share/yosyshq"
+                if [ ! -z ${HOME:+x} ]; then
+                    export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                    export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                    export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                    mkdir -p "\$HOME/.config/yosyshq" "\$HOME/.local/share/yosyshq"
+                fi
             EOT
         fi
         if [ ! -z "$(otool -L libexec/$(basename $binfile) | grep libgtk)" ]; then
@@ -105,11 +107,13 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export LC_ALL="C"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
-                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
-                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
-                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                if [ ! -z ${HOME:+x} ]; then
+                    export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                    export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                    export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                    export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                    mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                fi
                 "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
             EOT
         fi
@@ -179,11 +183,13 @@ for script in bin/* py3bin/*; do
                 export LD_LIBRARY_PATH="\$release_topdir_abs/lib"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
-                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
-                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
-                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                if [ ! -z ${HOME:+x} ]; then
+                    export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                    export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                    export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                    export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                    mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                fi
                 "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
                 exec "\$release_topdir_abs"/libexec/python3.8 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
             EOT

--- a/scripts/package-darwin.sh
+++ b/scripts/package-darwin.sh
@@ -75,12 +75,12 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export QT_LOGGING_RULES="*=false"
                 unset QT_QPA_PLATFORMTHEME
                 unset QT_STYLE_OVERRIDE
+                export LC_ALL="C"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
                 export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
                 export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
                 export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                export LC_ALL="C"
                 mkdir -p \$HOME/.config/yosyshq \$HOME/.local/share/yosyshq
             EOT
         fi
@@ -100,14 +100,14 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export GTK_DATA_PREFIX="\$release_topdir_abs"
                 export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
                 #export GTK_THEME="Adwaita"
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+                export LC_ALL="C"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
                 export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
                 export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
                 export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                export LC_ALL="C"
-                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
                 mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
                 "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
@@ -170,18 +170,18 @@ for script in bin/* py3bin/*; do
                 export GTK_DATA_PREFIX="\$release_topdir_abs"
                 export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
                 export GTK_THEME="Adwaita"
+                export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+                export PYTHONHOME="\$release_topdir_abs"
+                export PYTHONNOUSERSITE=1
+                export LC_ALL="C"
+                export LD_LIBRARY_PATH="\$release_topdir_abs/lib"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
                 export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
                 export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
                 export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
-                export LC_ALL="C"
-                export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
-                export LD_LIBRARY_PATH="\$release_topdir_abs/lib"
-                export PYTHONHOME="\$release_topdir_abs"
-                export PYTHONNOUSERSITE=1
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
                 mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
                 "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache

--- a/scripts/package-darwin.sh
+++ b/scripts/package-darwin.sh
@@ -78,10 +78,10 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export LC_ALL="C"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                mkdir -p \$HOME/.config/yosyshq \$HOME/.local/share/yosyshq
+                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                mkdir -p "\$HOME/.config/yosyshq" "\$HOME/.local/share/yosyshq"
             EOT
         fi
         if [ ! -z "$(otool -L libexec/$(basename $binfile) | grep libgtk)" ]; then
@@ -105,11 +105,11 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export LC_ALL="C"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
                 "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
             EOT
         fi
@@ -179,11 +179,11 @@ for script in bin/* py3bin/*; do
                 export LD_LIBRARY_PATH="\$release_topdir_abs/lib"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
                 "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
                 exec "\$release_topdir_abs"/libexec/python3.8 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
             EOT

--- a/scripts/package-darwin.sh
+++ b/scripts/package-darwin.sh
@@ -20,120 +20,120 @@ for bindir in bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
 
         mv $binfile libexec
         is_using_fonts=false
-        cat > $binfile << EOT
-#!/usr/bin/env bash
-release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
-release_bindir_abs="\$("\$release_bindir"/$rel_path/libexec/realpath "\$release_bindir")"
-release_topdir_abs="\$("\$release_bindir"/$rel_path/libexec/realpath "\$release_bindir/$rel_path")"
-export PATH="\$release_bindir_abs:\$PATH"
-EOT
+        cat > $binfile <<-EOT
+            #!/usr/bin/env bash
+            release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
+            release_bindir_abs="\$("\$release_bindir"/$rel_path/libexec/realpath "\$release_bindir")"
+            release_topdir_abs="\$("\$release_bindir"/$rel_path/libexec/realpath "\$release_bindir/$rel_path")"
+            export PATH="\$release_bindir_abs:\$PATH"
+        EOT
         if [ $bindir == 'py3bin' ]; then
-            cat >> $binfile << EOT
-export PYTHONEXECUTABLE="\$release_topdir_abs/bin/tabbypy3"
-EOT
+            cat >> $binfile <<-EOT
+                export PYTHONEXECUTABLE="\$release_topdir_abs/bin/tabbypy3"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep verilator)" ]; then
-            cat >> $binfile << EOT
-export VERILATOR_ROOT="\$release_topdir_abs/share/verilator"
-EOT
+            cat >> $binfile <<-EOT
+                export VERILATOR_ROOT="\$release_topdir_abs/share/verilator"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep openFPGALoader)" ]; then
-            cat >> $binfile << EOT
-export OPENFPGALOADER_SOJ_DIR="\$release_topdir_abs/share/openFPGALoader"
-EOT
+            cat >> $binfile <<-EOT
+                export OPENFPGALOADER_SOJ_DIR="\$release_topdir_abs/share/openFPGALoader"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep iverilog)" ]; then
-            cat >> $binfile << EOT
-set -- "-p" "VVP_EXECUTABLE=\$release_topdir_abs/bin/vvp" "\$@"
-EOT
+            cat >> $binfile <<-EOT
+                set -- "-p" "VVP_EXECUTABLE=\$release_topdir_abs/bin/vvp" "\$@"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep ghdl)" ]; then
-            cat >> $binfile << EOT
-export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
-EOT
+            cat >> $binfile <<-EOT
+                export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
+            EOT
         fi
         if [ ! -z "$(otool -L libexec/$(basename $binfile) | grep python)" ]; then
-            cat >> $binfile << EOT
-export PYTHONHOME="\$release_topdir_abs"
-export PYTHONNOUSERSITE=1
-export SSL_CERT_FILE="\$release_topdir_abs"/etc/cacert.pem
-EOT
+            cat >> $binfile <<-EOT
+                export PYTHONHOME="\$release_topdir_abs"
+                export PYTHONNOUSERSITE=1
+                export SSL_CERT_FILE="\$release_topdir_abs"/etc/cacert.pem
+            EOT
         fi
         if [ ! -z "$(otool -L libexec/$(basename $binfile) | grep tcl)" ]; then
-            cat >> $binfile << EOT
-export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
-EOT
+            cat >> $binfile <<-EOT
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+            EOT
         fi
         if [ ! -z "$(otool -L libexec/$(basename $binfile) | grep QtCore)" ]; then
             install_name_tool -add_rpath @executable_path/../Frameworks libexec/$(basename $binfile)
             if [ ${ARCH} == 'darwin-arm64' ]; then
                 rcodesign sign libexec/$(basename $binfile)
             fi
-            cat >> $binfile << EOT
-export QT_PLUGIN_PATH="\$release_topdir_abs/lib/qt5/plugins"
-export QT_LOGGING_RULES="*=false"
-unset QT_QPA_PLATFORMTHEME
-unset QT_STYLE_OVERRIDE
-export XDG_DATA_DIRS="\$release_topdir_abs"/share
-export XDG_CONFIG_DIRS="\$release_topdir_abs"
-export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-export LC_ALL="C"
-mkdir -p \$HOME/.config/yosyshq \$HOME/.local/share/yosyshq
-EOT
+            cat >> $binfile <<-EOT
+                export QT_PLUGIN_PATH="\$release_topdir_abs/lib/qt5/plugins"
+                export QT_LOGGING_RULES="*=false"
+                unset QT_QPA_PLATFORMTHEME
+                unset QT_STYLE_OVERRIDE
+                export XDG_DATA_DIRS="\$release_topdir_abs"/share
+                export XDG_CONFIG_DIRS="\$release_topdir_abs"
+                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
+                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
+                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export LC_ALL="C"
+                mkdir -p \$HOME/.config/yosyshq \$HOME/.local/share/yosyshq
+            EOT
         fi
         if [ ! -z "$(otool -L libexec/$(basename $binfile) | grep libgtk)" ]; then
-# Set and unset variables according to:
-# https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
-# https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
-            cat >> $binfile << EOT
-unset GTK_MODULES
-unset GTK2_MODULES
-#unset GTK3_MODULES
-export GTK_PATH="\$release_topdir_abs/lib"
-export GTK_IM_MODULE=""
-export GTK_IM_MODULE_FILE="/dev/null"
-export GTK2_RC_FILES="\$release_topdir_abs/lib/gtkrc"
-export GTK_EXE_PREFIX="\$release_topdir_abs"
-export GTK_DATA_PREFIX="\$release_topdir_abs"
-export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
-#export GTK_THEME="Adwaita"
-export XDG_DATA_DIRS="\$release_topdir_abs"/share
-export XDG_CONFIG_DIRS="\$release_topdir_abs"
-export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-export LC_ALL="C"
-export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
-export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
-"\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
-EOT
+            # Set and unset variables according to:
+            # https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
+            # https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
+            cat >> $binfile <<-EOT
+                unset GTK_MODULES
+                unset GTK2_MODULES
+                #unset GTK3_MODULES
+                export GTK_PATH="\$release_topdir_abs/lib"
+                export GTK_IM_MODULE=""
+                export GTK_IM_MODULE_FILE="/dev/null"
+                export GTK2_RC_FILES="\$release_topdir_abs/lib/gtkrc"
+                export GTK_EXE_PREFIX="\$release_topdir_abs"
+                export GTK_DATA_PREFIX="\$release_topdir_abs"
+                export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
+                #export GTK_THEME="Adwaita"
+                export XDG_DATA_DIRS="\$release_topdir_abs"/share
+                export XDG_CONFIG_DIRS="\$release_topdir_abs"
+                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
+                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
+                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export LC_ALL="C"
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
+            EOT
         fi
 
 if [ $binfile == "bin/yosys" ]; then
-        cat >> $binfile << EOT
-export TERMINFO="\$release_topdir_abs/share/terminfo"
-EOT
+        cat >> $binfile <<-EOT
+            export TERMINFO="\$release_topdir_abs/share/terminfo"
+        EOT
 fi
 
 if [ ${PRELOAD} == 'True' ]; then
     if [ $binfile == "bin/yosys" ] || [ $binfile == "bin/tabbylic" ]; then
         echo "Skipping"
     else
-        cat >> $binfile << EOT
-DYLD_INSERT_LIBRARIES="\$release_topdir_abs"/lib/preload.o exec "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
-EOT
+        cat >> $binfile <<-EOT
+            DYLD_INSERT_LIBRARIES="\$release_topdir_abs"/lib/preload.o exec "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
+        EOT
         chmod +x $binfile
         continue
     fi
 fi
-        cat >> $binfile << EOT
-exec "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
-EOT
+        cat >> $binfile <<-EOT
+            exec "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
+        EOT
         chmod +x $binfile
     done
 done
@@ -148,49 +148,49 @@ for script in bin/* py3bin/*; do
     rel_path=$(realpath --relative-to=bin .)
     if $(head -1 "${script}" | grep -q python3); then
         mv "${script}" libexec
-        cat > "${script}" <<EOT
-#!/usr/bin/env bash
-release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
-release_bindir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir/../bin")"
-release_topdir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir/$rel_path")"
-export PATH="\$release_bindir_abs:\$PATH"
-export PYTHONEXECUTABLE="\$release_bindir_abs/tabbypy3"
-EOT
+        cat > "${script}" <<-EOT
+            #!/usr/bin/env bash
+            release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
+            release_bindir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir/../bin")"
+            release_topdir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir/$rel_path")"
+            export PATH="\$release_bindir_abs:\$PATH"
+            export PYTHONEXECUTABLE="\$release_bindir_abs/tabbypy3"
+        EOT
         if [ $script == 'bin/xdot' ]; then
-# Set and unset variables according to:
-# https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
-# https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
-            cat >> "${script}" <<EOT
-unset GTK_MODULES
-unset GTK3_MODULES
-export GTK_PATH="\$release_topdir_abs/lib"
-export GTK_IM_MODULE=""
-export GTK_IM_MODULE_FILE="/dev/null"
-export GTK_EXE_PREFIX="\$release_topdir_abs"
-export GTK_DATA_PREFIX="\$release_topdir_abs"
-export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
-export GTK_THEME="Adwaita"
-export XDG_DATA_DIRS="\$release_topdir_abs"/share
-export XDG_CONFIG_DIRS="\$release_topdir_abs"
-export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
-export LC_ALL="C"
-export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
-export LD_LIBRARY_PATH="\$release_topdir_abs/lib"
-export PYTHONHOME="\$release_topdir_abs"
-export PYTHONNOUSERSITE=1
-export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
-"\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
-exec "\$release_topdir_abs"/libexec/python3.8 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
-EOT
+            # Set and unset variables according to:
+            # https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
+            # https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
+            cat >> "${script}" <<-EOT
+                unset GTK_MODULES
+                unset GTK3_MODULES
+                export GTK_PATH="\$release_topdir_abs/lib"
+                export GTK_IM_MODULE=""
+                export GTK_IM_MODULE_FILE="/dev/null"
+                export GTK_EXE_PREFIX="\$release_topdir_abs"
+                export GTK_DATA_PREFIX="\$release_topdir_abs"
+                export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
+                export GTK_THEME="Adwaita"
+                export XDG_DATA_DIRS="\$release_topdir_abs"/share
+                export XDG_CONFIG_DIRS="\$release_topdir_abs"
+                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
+                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
+                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+                export LC_ALL="C"
+                export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
+                export LD_LIBRARY_PATH="\$release_topdir_abs/lib"
+                export PYTHONHOME="\$release_topdir_abs"
+                export PYTHONNOUSERSITE=1
+                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
+                exec "\$release_topdir_abs"/libexec/python3.8 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
+            EOT
         else
-        cat >> "${script}" <<EOT
-exec \$release_bindir_abs/tabbypy3 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
-EOT
+        cat >> "${script}" <<-EOT
+            exec \$release_bindir_abs/tabbypy3 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
+        EOT
         fi
         chmod +x "${script}"
     fi
@@ -210,12 +210,12 @@ fi
 
 if [ -f "bin/yosys-config" ]; then
     mv bin/yosys-config bin/yosys-config.orig
-    cat > bin/yosys-config << EOT
-#!/usr/bin/env bash
-release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
-release_bindir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir")"
-release_topdir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir/$rel_path")"
-EOT
+    cat > bin/yosys-config <<-EOT
+        #!/usr/bin/env bash
+        release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
+        release_bindir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir")"
+        release_topdir_abs="\$("\$release_bindir"/../libexec/realpath "\$release_bindir/$rel_path")"
+    EOT
     cat bin/yosys-config.orig >> bin/yosys-config
     rm bin/yosys-config.orig
     sed -i "s,\"/yosyshq,\${release_topdir_abs}\",g" bin/yosys-config

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -95,10 +95,10 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
             EOT
         fi
         if [ ! -z "$(lddtree -l libexec/$(basename $binfile) | grep gtk)" ]; then
@@ -120,11 +120,11 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
                 "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
             EOT
         fi
@@ -133,7 +133,7 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
             cat >> $binfile <<-EOT
                 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
                 export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
-                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
+                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > "\$FONTCONFIG_FILE"
             EOT
         fi
 
@@ -194,11 +194,11 @@ for script in bin/* py3bin/*; do
                 export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
                 "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
                 export LC_ALL="C"
                 export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
@@ -208,7 +208,7 @@ for script in bin/* py3bin/*; do
             cat >> "${script}" <<-EOT
                 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
                 export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
-                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
+                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > "\$FONTCONFIG_FILE"
             EOT
         fi
         cat >> "${script}" <<-EOT

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -95,10 +95,12 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
-                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
-                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
-                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                if [ ! -z ${HOME:+x} ]; then
+                    export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                    export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                    export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                    mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                fi
             EOT
         fi
         if [ ! -z "$(lddtree -l libexec/$(basename $binfile) | grep gtk)" ]; then
@@ -120,11 +122,13 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
-                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
-                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
-                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                if [ ! -z ${HOME:+x} ]; then
+                    export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                    export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                    export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                    export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                    mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                fi
                 "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
             EOT
         fi
@@ -132,8 +136,10 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
         if $is_using_fonts; then
             cat >> $binfile <<-EOT
                 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
-                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
-                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > "\$FONTCONFIG_FILE"
+                if [ ! -z ${HOME:+x} ]; then
+                    export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
+                    sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > "\$FONTCONFIG_FILE"
+                fi
             EOT
         fi
 
@@ -194,11 +200,13 @@ for script in bin/* py3bin/*; do
                 export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
-                export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
-                export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
-                export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
-                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-                mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                if [ ! -z ${HOME:+x} ]; then
+                    export XDG_CONFIG_HOME="\$HOME/.config/yosyshq"
+                    export XDG_CACHE_HOME="\$HOME/.cache/yosyshq"
+                    export XDG_DATA_HOME="\$HOME/.local/share/yosyshq"
+                    export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                    mkdir -p "\$XDG_CONFIG_HOME" "\$XDG_CACHE_HOME" "\$XDG_DATA_HOME"
+                fi
                 "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
                 export LC_ALL="C"
                 export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
@@ -207,8 +215,10 @@ for script in bin/* py3bin/*; do
         if $is_using_fonts; then
             cat >> "${script}" <<-EOT
                 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
-                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
-                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > "\$FONTCONFIG_FILE"
+                if [ ! -z ${HOME:+x} ]; then
+                    export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
+                    sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > "\$FONTCONFIG_FILE"
+                fi
             EOT
         fi
         cat >> "${script}" <<-EOT

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -33,124 +33,124 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
         done
         mv $binfile libexec
         is_using_fonts=false
-        cat > $binfile << EOT
-#!/usr/bin/env bash
-release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
-release_bindir_abs="\$(readlink -f "\$release_bindir")"
-release_topdir_abs="\$(readlink -f "\$release_bindir/$rel_path")"
-export PATH="\$release_bindir_abs:\$PATH"
-EOT
+        cat > $binfile <<-EOT
+            #!/usr/bin/env bash
+            release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
+            release_bindir_abs="\$(readlink -f "\$release_bindir")"
+            release_topdir_abs="\$(readlink -f "\$release_bindir/$rel_path")"
+            export PATH="\$release_bindir_abs:\$PATH"
+        EOT
 
         if [ $bindir == 'py3bin' ]; then
-            cat >> $binfile << EOT
-export PYTHONEXECUTABLE="\$release_topdir_abs/bin/tabbypy3"
-EOT
+            cat >> $binfile <<-EOT
+                export PYTHONEXECUTABLE="\$release_topdir_abs/bin/tabbypy3"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep verilator)" ]; then
-            cat >> $binfile << EOT
-export VERILATOR_ROOT="\$release_topdir_abs/share/verilator"
-EOT
+            cat >> $binfile <<-EOT
+                export VERILATOR_ROOT="\$release_topdir_abs/share/verilator"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep openFPGALoader)" ]; then
-            cat >> $binfile << EOT
-export OPENFPGALOADER_SOJ_DIR="\$release_topdir_abs/share/openFPGALoader"
-EOT
+            cat >> $binfile <<-EOT
+                export OPENFPGALOADER_SOJ_DIR="\$release_topdir_abs/share/openFPGALoader"
+            EOT
         fi
         if [ ! -z "$(basename $binfile | grep iverilog)" ]; then
-            cat >> $binfile << EOT
-set -- "-p" "VVP_EXECUTABLE=\$release_topdir_abs/bin/vvp" "\$@"
-EOT
+            cat >> $binfile <<-EOT
+                set -- "-p" "VVP_EXECUTABLE=\$release_topdir_abs/bin/vvp" "\$@"
+            EOT
         fi
         if [ ! -z "$(strings libexec/$(basename $binfile) | grep ghdl)" ]; then
-            cat >> $binfile << EOT
-export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
-EOT
+            cat >> $binfile <<-EOT
+                export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
+            EOT
         fi
         if [ $binfile == "bin/yosys" ] && [ -f "share/yosys/plugins/ghdl.so" ]; then
-            cat >> $binfile << EOT
-export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
-EOT
+            cat >> $binfile <<-EOT
+                export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"
+            EOT
         fi
         if [ ! -z "$(lddtree -l libexec/$(basename $binfile) | grep python)" ]; then
-            cat >> $binfile << EOT
-export PYTHONHOME="\$release_topdir_abs"
-export PYTHONNOUSERSITE=1
-export SSL_CERT_FILE="\$release_topdir_abs"/etc/cacert.pem
-EOT
+            cat >> $binfile <<-EOT
+                export PYTHONHOME="\$release_topdir_abs"
+                export PYTHONNOUSERSITE=1
+                export SSL_CERT_FILE="\$release_topdir_abs"/etc/cacert.pem
+            EOT
         fi
         if [ ! -z "$(lddtree -l libexec/$(basename $binfile) | grep tcl)" ]; then
-            cat >> $binfile << EOT
-export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
-EOT
+            cat >> $binfile <<-EOT
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+            EOT
         fi
         if [ ! -z "$(lddtree -l libexec/$(basename $binfile) | grep Qt5)" ]; then
             is_using_fonts=true
-            cat >> $binfile << EOT
-export QT_PLUGIN_PATH="\$release_topdir_abs/lib/qt5/plugins"
-export QT_LOGGING_RULES="*=false"
-unset QT_QPA_PLATFORMTHEME
-unset QT_STYLE_OVERRIDE
-export XDG_DATA_DIRS="\$release_topdir_abs"/share
-export XDG_CONFIG_DIRS="\$release_topdir_abs"
-export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-export XDG_CURRENT_DESKTOP="KDE"
-export LC_ALL="C"
-mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
-EOT
+            cat >> $binfile <<-EOT
+                export QT_PLUGIN_PATH="\$release_topdir_abs/lib/qt5/plugins"
+                export QT_LOGGING_RULES="*=false"
+                unset QT_QPA_PLATFORMTHEME
+                unset QT_STYLE_OVERRIDE
+                export XDG_DATA_DIRS="\$release_topdir_abs"/share
+                export XDG_CONFIG_DIRS="\$release_topdir_abs"
+                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
+                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
+                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CURRENT_DESKTOP="KDE"
+                export LC_ALL="C"
+                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+            EOT
         fi
         if [ ! -z "$(lddtree -l libexec/$(basename $binfile) | grep gtk)" ]; then
-# Set and unset variables according to:
-# https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
-# https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
+            # Set and unset variables according to:
+            # https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
+            # https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
             is_using_fonts=true
-            cat >> $binfile << EOT
-unset GTK_MODULES
-unset GTK3_MODULES
-export GTK_PATH="\$release_topdir_abs/lib"
-export GTK_IM_MODULE=""
-export GTK_IM_MODULE_FILE="/dev/null"
-export GTK_EXE_PREFIX="\$release_topdir_abs"
-export GTK_DATA_PREFIX="\$release_topdir_abs"
-export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
-export GTK_THEME="Adwaita"
-export XDG_DATA_DIRS="\$release_topdir_abs"/share
-export XDG_CONFIG_DIRS="\$release_topdir_abs"
-export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-export XDG_CURRENT_DESKTOP="KDE"
-export LC_ALL="C"
-export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
-"\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
-EOT
+            cat >> $binfile <<-EOT
+                unset GTK_MODULES
+                unset GTK3_MODULES
+                export GTK_PATH="\$release_topdir_abs/lib"
+                export GTK_IM_MODULE=""
+                export GTK_IM_MODULE_FILE="/dev/null"
+                export GTK_EXE_PREFIX="\$release_topdir_abs"
+                export GTK_DATA_PREFIX="\$release_topdir_abs"
+                export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
+                export GTK_THEME="Adwaita"
+                export XDG_DATA_DIRS="\$release_topdir_abs"/share
+                export XDG_CONFIG_DIRS="\$release_topdir_abs"
+                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
+                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
+                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CURRENT_DESKTOP="KDE"
+                export LC_ALL="C"
+                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
+            EOT
         fi
 
         if $is_using_fonts; then
-            cat >> $binfile << EOT
-export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
-export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
-sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
-EOT
+            cat >> $binfile <<-EOT
+                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
+                export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
+                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
+            EOT
         fi
 
 if [ ${PRELOAD} == 'True' ]; then
     if [ $binfile == "bin/yosys" ] || [ $binfile == "bin/tabbylic" ]; then
         echo "Skipping"
     else
-        cat >> $binfile << EOT
-exec "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib --preload "\$release_topdir_abs"/lib/preload.o "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
-EOT
+        cat >> $binfile <<-EOT
+            exec "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib --preload "\$release_topdir_abs"/lib/preload.o "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
+        EOT
         chmod +x $binfile
         continue
     fi
 fi
-        cat >> $binfile << EOT
-exec "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
-EOT
+        cat >> $binfile <<-EOT
+            exec "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/$(basename $binfile) "\$@"
+        EOT
         chmod +x $binfile
     done
 done
@@ -165,55 +165,55 @@ for script in bin/* py3bin/*; do
     rel_path=$(realpath --relative-to=bin .)
     if $(head -1 "${script}" | grep -q python3); then
         mv "${script}" libexec
-        cat > "${script}" <<EOT
-#!/usr/bin/env bash
-release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
-release_bindir_abs="\$(readlink -f "\$release_bindir/../bin")"
-release_topdir_abs="\$(readlink -f "\$release_bindir/$rel_path")"
-export PATH="\$release_bindir_abs:\$PATH"
-export PYTHONEXECUTABLE="\$release_bindir_abs/tabbypy3"
-EOT
+        cat > "${script}" <<-EOT
+            #!/usr/bin/env bash
+            release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
+            release_bindir_abs="\$(readlink -f "\$release_bindir/../bin")"
+            release_topdir_abs="\$(readlink -f "\$release_bindir/$rel_path")"
+            export PATH="\$release_bindir_abs:\$PATH"
+            export PYTHONEXECUTABLE="\$release_bindir_abs/tabbypy3"
+        EOT
         is_using_fonts=false
         if [ $script == 'bin/xdot' ]; then
-# Set and unset variables according to:
-# https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
-# https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
+            # Set and unset variables according to:
+            # https://refspecs.linuxbase.org/gtk/2.6/gtk/gtk-running.html
+            # https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html
             is_using_fonts=true
-            cat >> "${script}" <<EOT
-unset GTK_MODULES
-unset GTK3_MODULES
-export GTK_PATH="\$release_topdir_abs/lib"
-export GTK_IM_MODULE=""
-export GTK_IM_MODULE_FILE="/dev/null"
-export GTK_EXE_PREFIX="\$release_topdir_abs"
-export GTK_DATA_PREFIX="\$release_topdir_abs"
-export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
-export GTK_THEME="Adwaita"
-export XDG_DATA_DIRS="\$release_topdir_abs"/share
-export XDG_CONFIG_DIRS="\$release_topdir_abs"
-export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
-export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
-export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-export XDG_CURRENT_DESKTOP="KDE"
-export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
-export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
-mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
-"\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
-export LC_ALL="C"
-export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
-EOT
+            cat >> "${script}" <<-EOT
+                unset GTK_MODULES
+                unset GTK3_MODULES
+                export GTK_PATH="\$release_topdir_abs/lib"
+                export GTK_IM_MODULE=""
+                export GTK_IM_MODULE_FILE="/dev/null"
+                export GTK_EXE_PREFIX="\$release_topdir_abs"
+                export GTK_DATA_PREFIX="\$release_topdir_abs"
+                export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
+                export GTK_THEME="Adwaita"
+                export XDG_DATA_DIRS="\$release_topdir_abs"/share
+                export XDG_CONFIG_DIRS="\$release_topdir_abs"
+                export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
+                export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
+                export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
+                export XDG_CURRENT_DESKTOP="KDE"
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+                export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
+                mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
+                "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
+                export LC_ALL="C"
+                export GI_TYPELIB_PATH="\$release_topdir_abs/lib/girepository-1.0"
+            EOT
         fi
         if $is_using_fonts; then
-            cat >> "${script}" <<EOT
-export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
-export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
-sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
-EOT
+            cat >> "${script}" <<-EOT
+                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
+                export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
+                sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
+            EOT
         fi
-        cat >> "${script}" <<EOT
-exec \$release_bindir_abs/tabbypy3 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
-EOT
+        cat >> "${script}" <<-EOT
+            exec \$release_bindir_abs/tabbypy3 "\$release_topdir_abs"/libexec/$(basename $script) "\$@"
+        EOT
         chmod +x "${script}"
     fi
 done
@@ -241,12 +241,12 @@ fi
 
 if [ -f "bin/yosys-config" ]; then
     mv bin/yosys-config bin/yosys-config.orig
-    cat > bin/yosys-config << EOT
-#!/usr/bin/env bash
-release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
-release_bindir_abs="\$(readlink -f "\$release_bindir")"
-release_topdir_abs="\$(readlink -f "\$release_bindir/$rel_path")"
-EOT
+    cat > bin/yosys-config <<-EOT
+        #!/usr/bin/env bash
+        release_bindir="\$(dirname "\${BASH_SOURCE[0]}")"
+        release_bindir_abs="\$(readlink -f "\$release_bindir")"
+        release_topdir_abs="\$(readlink -f "\$release_bindir/$rel_path")"
+    EOT
     cat bin/yosys-config.orig >> bin/yosys-config
     rm bin/yosys-config.orig
     sed -i "s,\"/yosyshq,\${release_topdir_abs}\",g" bin/yosys-config

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -91,13 +91,13 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export QT_LOGGING_RULES="*=false"
                 unset QT_QPA_PLATFORMTHEME
                 unset QT_STYLE_OVERRIDE
+                export LC_ALL="C"
+                export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
                 export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
                 export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
                 export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                export XDG_CURRENT_DESKTOP="KDE"
-                export LC_ALL="C"
                 mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
             EOT
         fi
@@ -116,13 +116,13 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
                 export GTK_DATA_PREFIX="\$release_topdir_abs"
                 export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
                 export GTK_THEME="Adwaita"
+                export LC_ALL="C"
+                export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
                 export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
                 export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
                 export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                export XDG_CURRENT_DESKTOP="KDE"
-                export LC_ALL="C"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
                 mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
                 "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
@@ -131,8 +131,8 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
 
         if $is_using_fonts; then
             cat >> $binfile <<-EOT
-                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
                 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
+                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
                 sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
             EOT
         fi
@@ -189,14 +189,14 @@ for script in bin/* py3bin/*; do
                 export GTK_DATA_PREFIX="\$release_topdir_abs"
                 export GDK_PIXBUF_MODULEDIR="\$release_topdir_abs/lib/gdk-pixbuf-2.0/loaders"
                 export GTK_THEME="Adwaita"
+                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
+                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
+                export XDG_CURRENT_DESKTOP="KDE"
                 export XDG_DATA_DIRS="\$release_topdir_abs"/share
                 export XDG_CONFIG_DIRS="\$release_topdir_abs"
                 export XDG_CONFIG_HOME=\$HOME/.config/yosyshq
                 export XDG_CACHE_HOME=\$HOME/.cache/yosyshq
                 export XDG_DATA_HOME=\$HOME/.local/share/yosyshq
-                export XDG_CURRENT_DESKTOP="KDE"
-                export TCL_LIBRARY="\$release_topdir_abs/lib/tcl8.6"
-                export TK_LIBRARY="\$release_topdir_abs/lib/tk8.6"
                 export GDK_PIXBUF_MODULE_FILE="\$XDG_CACHE_HOME/loaders.cache"
                 mkdir -p \$XDG_CONFIG_HOME \$XDG_CACHE_HOME \$XDG_DATA_HOME
                 "\$release_topdir_abs"/lib/$ldlinuxname --inhibit-cache --inhibit-rpath "" --library-path "\$release_topdir_abs"/lib "\$release_topdir_abs"/libexec/gdk-pixbuf-query-loaders --update-cache
@@ -206,8 +206,8 @@ for script in bin/* py3bin/*; do
         fi
         if $is_using_fonts; then
             cat >> "${script}" <<-EOT
-                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
                 export FONTCONFIG_PATH="\$release_topdir_abs/etc/fonts"
+                export FONTCONFIG_FILE="\$XDG_CONFIG_HOME/fonts.conf"
                 sed "s|TARGET_DIR|\$release_topdir_abs|g" "\$release_topdir_abs/etc/fonts/fonts.conf.template" > \$FONTCONFIG_FILE
             EOT
         fi


### PR DESCRIPTION
Per #75, we are having issues with Glasgow, where `${HOME}` is forcibly unset - these scripts expect it to be set and get upset when trying to execute what resolves to `mkdir /.config`.

The culmination of this PR is a fix to only set up the derived environment variables when `${HOME}` is actually available - something that I believe is only really required for the UI component fo the toolchain anyway.

I took the opportunity for some other enhancements too.