### PR TITLE
Mention YoWASP in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,6 @@ To build specific target and architecture:
 ./builder.py build --target=yosys --arch=linux-arm64
 ```
 
+# Alternatives
+
+If your project is primarily written in Python (using tools such as Amaranth or LiteX), and you only need synthesis and PnR tools, you might find [YoWASP](https://yowasp.org) more suited to your needs since it allows managing installation and versioning of these tools in the same way as any other Python package dependencies.


### PR DESCRIPTION
I've found it before that people who could really benefit from using YoWASP (where ease of dependency management was more important than breadth of the toolchain or its performance) were using this repository because they did not know about YoWASP. I am linking to this repo from the YoWASP homepage, so I think it only fair to add a link back.