### PR TITLE
Remove com.apple.quarantine attribute from directories (macOS)

### DIFF
--- a/default/patches/activate
+++ b/default/patches/activate
@@ -1,4 +1,4 @@
 echo "Please wait"
-echo "Removing quarantine flag from all files ..."
-sudo find . -type f -exec xattr -d com.apple.quarantine {} 2> /dev/null \;
+echo "Removing quarantine flag from all files and directories..."
+sudo find . -exec xattr -d com.apple.quarantine {} 2> /dev/null \;
 echo "Done"


### PR DESCRIPTION
Remove **com.apple.quarantine** attribute from directories as well as files.

The existing `default/patches/activate` script removes the com.apple.quarantine attribute from files, but not directories.

With the quarantine attribute on directories, you can't launch nextpnr-ecp5 on macOS:

```shell
/opt/oss-cad-suite-2024-02-12/bin/nextpnr-ecp5 --version
dyld[62272]: Library not loaded: @rpath/QtOpenGL.framework/Versions/5/QtOpenGL
  Referenced from: <23B7E402-A7B7-3209-8478-43336856FB26> /opt/oss-cad-suite-2024-02-12/libexec/nextpnr-ecp5
  Reason: tried: '/opt/oss-cad-suite-2024-02-12/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL' (code signature in <6E7EC62A-94B8-3AA7-8F32-A6B02488DD20> '/opt/oss-cad-suite-2024-02-12/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL' not valid for use in process: library load disallowed by system policy), '/opt/oss-cad-suite-2024-02-12/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL' (code signature in <6E7EC62A-94B8-3AA7-8F32-A6B02488DD20> '/opt/oss-cad-suite-2024-02-12/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL' not valid for use in process: library load disallowed by system policy), '/Library/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL' (no such file), '/System/Library/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL' (no such file, not in dyld cache)
[1]    62272 abort      /opt/oss-cad-suite-2024-02-12/bin/nextpnr-ecp5 --version
```