### PR TITLE
Add environment file for fish shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ export PATH="<extracted_location>/oss-cad-suite/bin:$PATH"
 source <extracted_location>/oss-cad-suite/environment
 ```
 
+Linux and macOS (fish shell)
+```bash
+fish_add_path "<extracted_location>/oss-cad-suite/bin"
+
+# or
+
+source <extracted_location>/oss-cad-suite/environment.fish
+```
+
 Windows
 ```batch
 from existing CMD prompt:

--- a/default/patches/README
+++ b/default/patches/README
@@ -16,6 +16,9 @@ Linux and macOS
 ---------------
 export PATH="<extracted_location>/oss-cad-suite/bin:$PATH"
 
+with fish shell:
+fish_add_path "<extracted_location>/oss-cad-suite/bin"
+
 Windows
 -------
 from existing shell:
@@ -32,3 +35,7 @@ If you want to use the bundled version of Python, for example with nmigen, nextp
 We also provide a virtual environment that you can setup like this:
 
 source <extracted_location>/oss-cad-suite/environment
+
+or with fish shell:
+
+source <extracted_location>/oss-cad-suite/environment.fish

--- a/default/patches/environment.fish
+++ b/default/patches/environment.fish
@@ -1,0 +1,60 @@
+#!/usr/bin/env fish
+
+function deactivate -d "Deactivate the ___BRANDING___ virtual environment"
+
+    if set --query _OLD_ENVIRONMENT_PATH
+        set --export PATH $_OLD_ENVIRONMENT_PATH
+        set --erase _OLD_ENVIRONMENT_PATH
+    end
+
+    if set --query _OLD_ENVIRONMENT_PYTHONHOME
+        set --export PYTHONHOME $_OLD_ENVIRONMENT_PYTHONHOME
+        set --erase _OLD_ENVIRONMENT_PYTHONHOME
+    end
+
+    set --erase VIRTUAL_ENV
+    set --erase VERILATOR_ROOT
+    set --erase GHDL_PREFIX
+
+    if functions --query _old_environment_fish_prompt
+        functions --erase fish_prompt
+        functions --copy _old_environment_fish_prompt fish_prompt
+        functions --erase _old_environment_fish_prompt
+    end
+
+    if test (count $argv) -eq 0; or test $argv[1] != "nondestructive"
+        functions --erase deactivate
+    end
+
+end
+
+deactivate nondestructive
+
+set --local release_current_dir (dirname (status -f))
+
+if test (uname) = "Darwin"
+    set --global release_topdir_abs ($release_current_dir/libexec/realpath $release_current_dir)
+else
+    set --global release_topdir_abs (realpath $release_current_dir)
+end
+
+set --export VIRTUAL_ENV '___BRANDING___'
+
+set --global _OLD_ENVIRONMENT_PATH "$PATH"
+set --export PATH "$release_topdir_abs/bin:$release_topdir_abs/py3bin:$PATH"
+
+if set --query PYTHONHOME
+    set --export _OLD_ENVIRONMENT_PYTHONHOME "$PYTHONHOME"
+    set --erase PYTHONHOME
+end
+
+functions --copy fish_prompt _old_environment_fish_prompt
+function fish_prompt -d "Write out the prompt"
+    set_color magenta
+    echo -n -s '(' $VIRTUAL_ENV ') '
+    set_color normal
+    _old_environment_fish_prompt
+end
+
+set --export VERILATOR_ROOT "$release_topdir_abs/share/verilator"
+set --export GHDL_PREFIX "$release_topdir_abs/lib/ghdl"

--- a/default/rules/resources-min.py
+++ b/default/rules/resources-min.py
@@ -3,6 +3,6 @@ from src.base import Target
 Target(
 	name = 'system-resources-min',
 	sources = [ ],
-	patches = [ 'fonts.conf.template', 'win-launcher.c', 'environment', 'environment.bat', 'start.bat', 'cacert.pem', 'tabbyadm' ],
+	patches = [ 'fonts.conf.template', 'win-launcher.c', 'environment', 'environment.fish', 'environment.bat', 'start.bat', 'cacert.pem', 'tabbyadm' ],
 	tools = {},
 )

--- a/default/rules/resources.py
+++ b/default/rules/resources.py
@@ -3,13 +3,13 @@ from src.base import Target
 Target(
 	name = 'system-resources',
 	sources = [ ],
-	patches = [ 'fonts.conf.template', 'win-launcher.c', 'environment', 'environment.bat', 'start.bat', 'cacert.pem', 'tabbyadm' ],
+	patches = [ 'fonts.conf.template', 'win-launcher.c', 'environment', 'environment.fish', 'environment.bat', 'start.bat', 'cacert.pem', 'tabbyadm' ],
 	tools = {},
 )
 
 Target(
 	name = 'system-resources-tabby',
 	sources = [ ],
-	patches = [ 'fonts.conf.template', 'win-launcher.c', 'environment', 'environment.bat', 'start.bat', 'cacert.pem', 'tabbyadm' ],
+	patches = [ 'fonts.conf.template', 'win-launcher.c', 'environment', 'environment.fish', 'environment.bat', 'start.bat', 'cacert.pem', 'tabbyadm' ],
 	tools = {},
 )

--- a/scripts/package-darwin.sh
+++ b/scripts/package-darwin.sh
@@ -9,6 +9,9 @@ cp /opt/local/bin/realpath libexec/.
 
 cp ${PATCHES_DIR}/${README} ${OUTPUT_DIR}${INSTALL_PREFIX}/README
 sed "s|___BRANDING___|${BRANDING}|g" -i ${OUTPUT_DIR}${INSTALL_PREFIX}/environment
+if [ -f "${OUTPUT_DIR}${INSTALL_PREFIX}/environment.fish" ]; then
+    sed "s|___BRANDING___|${BRANDING}|g" -i ${OUTPUT_DIR}${INSTALL_PREFIX}/environment.fish
+fi
 if [ -f "${OUTPUT_DIR}${INSTALL_PREFIX}/bin/tabbyadm" ]; then
     sed "s|___BRANDING___|${BRANDING}|g" -i ${OUTPUT_DIR}${INSTALL_PREFIX}/bin/tabbyadm
 fi

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -15,6 +15,9 @@ fi
 
 cp ${PATCHES_DIR}/${README} ${OUTPUT_DIR}${INSTALL_PREFIX}/README
 sed "s|___BRANDING___|${BRANDING}|g" -i ${OUTPUT_DIR}${INSTALL_PREFIX}/environment
+if [ -f "${OUTPUT_DIR}${INSTALL_PREFIX}/environment.fish" ]; then
+    sed "s|___BRANDING___|${BRANDING}|g" -i ${OUTPUT_DIR}${INSTALL_PREFIX}/environment.fish
+fi
 if [ -f "${OUTPUT_DIR}${INSTALL_PREFIX}/bin/tabbyadm" ]; then
     sed "s|___BRANDING___|${BRANDING}|g" -i ${OUTPUT_DIR}${INSTALL_PREFIX}/bin/tabbyadm
 fi


### PR DESCRIPTION
This commit adds support for the fish shell by adding a `environment.fish` file and fixes #104 by adding that feature.  It should behave like the `environment` file for bash and zsh.  I have also added documentation in the README for it and have changed all the relevant locations.

Let me know if anything requires changing, I could remove it from the minimal installs for example but for now have added it there too.