### PR TITLE
Fix Windows not building if `py3bin` is not present

### DIFF
--- a/scripts/package-windows.sh
+++ b/scripts/package-windows.sh
@@ -31,8 +31,10 @@ for script in bin/* py3bin/*; do
     fi
 done
 
-cp -f py3bin/* lib/.
-rm -rf py3bin
+if [ -d "py3bin" ]; then
+	cp -f py3bin/* lib/.
+	rm -rf py3bin
+fi
 
 # Remove general purpose launcher
 rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/win-launcher.exe


### PR DESCRIPTION
Windows 'top_package' targets without Python are currently failing to build because `package-windows.sh` is unconditionally copying files from `py3bin/`. This PR fixes that.