### PR TITLE
Fix Windows builds that depend on `system-resources-min`

### DIFF
--- a/default/scripts/system-resources-min.sh
+++ b/default/scripts/system-resources-min.sh
@@ -22,6 +22,8 @@ if [ ${ARCH_BASE} == 'darwin' ]; then
 
 fi
 if [ ${ARCH_BASE} == 'windows' ]; then
+    ${CC} -DGUI=0 -O -s -o ${OUTPUT_DIR}${INSTALL_PREFIX}/win-launcher.exe ${PATCHES_DIR}/win-launcher.c
+
     cp ${PATCHES_DIR}/environment.bat ${OUTPUT_DIR}${INSTALL_PREFIX}/.
     cp ${PATCHES_DIR}/start.bat ${OUTPUT_DIR}${INSTALL_PREFIX}/.
 


### PR DESCRIPTION
Found another small Windows inconsistency 🙂 

Windows builds depending on `system-resources-min` instead of the full `system-resources` will currently fail because `win-launcher.c` is never compiled, but it is used in the packaging process. I copied the compilation command from `system-resources-tabby` (which is sourced by `system-resources`) into the min version, which fixes the issue.
