### PR TITLE
GHDL and ghdl-yosys-plugin support for darwin-arm64

### DIFF
--- a/default/rules/ghdl.py
+++ b/default/rules/ghdl.py
@@ -11,5 +11,5 @@ SourceLocation(
 Target(
 	name = 'ghdl',
 	sources = [ 'ghdl' ],
-	arch = [ 'linux-x64', 'darwin-x64' ],
+	arch = [ 'linux-x64', 'darwin-x64', 'darwin-arm64' ],
 )

--- a/default/rules/yosys.py
+++ b/default/rules/yosys.py
@@ -51,7 +51,7 @@ Target(
 	name = 'ghdl-yosys-plugin',
 	sources = [ 'ghdl-yosys-plugin' ],
 	dependencies = [ 'ghdl', 'yosys' ],
-	arch = [ 'linux-x64', 'darwin-x64' ],
+	arch = [ 'linux-x64', 'darwin-x64', 'darwin-arm64' ],
 )
 
 SourceLocation(

--- a/default/scripts/ghdl-yosys-plugin.sh
+++ b/default/scripts/ghdl-yosys-plugin.sh
@@ -1,6 +1,6 @@
 cd ghdl-yosys-plugin
 sed -i 's,/yosyshq/share,/yosys/yosyshq/share,g' ../yosys/yosyshq/bin/yosys-config
-if [ ${ARCH} == 'darwin-x64' ]; then
+if [ ${ARCH} == 'darwin-x64' ] || [ ${ARCH} == 'darwin-arm64' ]; then
     sed -i '11,13d' Makefile
     make GHDL=../ghdl/yosyshq/bin/ghdl YOSYS_CONFIG=../yosys/yosyshq/bin/yosys-config CFLAGS="-I ../yosys/yosyshq/share/yosys/include" LIBGHDL_LIB="${BUILD_DIR}/ghdl${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib" LIBGHDL_INC="${BUILD_DIR}/ghdl${INSTALL_PREFIX}/include/"
 else

--- a/default/scripts/ghdl.sh
+++ b/default/scripts/ghdl.sh
@@ -16,12 +16,23 @@ elif [ ${ARCH} == 'darwin-x64' ]; then
     wget https://github.com/mmicko/macos-resources/releases/download/v2/libgnat-2019.dylib
     cp libgnat-2019.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/.
     exit 0
+elif [ ${ARCH} == 'darwin-arm64' ]; then
+    wget https://github.com/ghdl/ghdl/releases/download/nightly/ghdl-macos14-ARM64-llvm-jit.tgz
+    mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}
+    tar xvfz ghdl-macos14-ARM64-llvm-jit.tgz -C ${OUTPUT_DIR}${INSTALL_PREFIX}
+    install_name_tool -id @executable_path/../lib/libghdl-5_0_0_dev.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    GNAT_NATIVE_VERSION="14.2.0"
+    wget https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-${GNAT_NATIVE_VERSION}-1/gnat-aarch64-darwin-${GNAT_NATIVE_VERSION}-1.tar.gz
+    tar xvfz gnat-aarch64-darwin-${GNAT_NATIVE_VERSION}-1.tar.gz
+    cp gnat-aarch64-darwin-${GNAT_NATIVE_VERSION}-1/lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/.
+    cp gnat-aarch64-darwin-${GNAT_NATIVE_VERSION}-1/lib/gcc/aarch64-apple-darwin23.6.0/${GNAT_NATIVE_VERSION}/adalib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/.
+    exit 0
 elif [ ${ARCH} == 'windows-x64' ]; then
     sed -i 's,grt-all libs.vhdl.llvm all.vpi,grt-all all.vpi,g' Makefile.in
     sed -i 's,install.llvm.program install.vhdllib,install.llvm.program ,g' Makefile.in
     sed -i '130,133d' Makefile.in
     export GNATMAKE=${CROSS_NAME}-gnatmake
-    sed -i 's,$(LDFLAGS) `$(LLVM_LDFLAGS)`,`$(LLVM_LDFLAGS)` $(LDFLAGS),g' src/ortho/llvm6/Makefile 
+    sed -i 's,$(LDFLAGS) `$(LLVM_LDFLAGS)`,`$(LLVM_LDFLAGS)` $(LDFLAGS),g' src/ortho/llvm6/Makefile
     param=--with-llvm-config="/usr/x86_64-w64-mingw32/bin/llvm-config"
     LDFLAGS="-luuid -lole32 -lz -lssp"
 fi
@@ -30,7 +41,7 @@ fi
         --enable-libghdl \
         --enable-synth \
         ${param} LDFLAGS="${LDFLAGS}"
-        
+
 make DESTDIR=${OUTPUT_DIR} -j${NPROC}
 make DESTDIR=${OUTPUT_DIR} -j${NPROC} install
 


### PR DESCRIPTION
I've gone with the `LLVM-jit` backend for GHDL, as that is the most recently changed one.
This can of course be changed if you prefer a different backend.

Either GHDL, the plugin, or both depend on `libgnat-14.dylib` and `libgcc_s.1.1.dylib`, so I fetch those from the Alire project's `gnat_native` toolchain builds. These libraries could be added as a `v4` release of @mmicko's `macos-resources` repo to reduce the download size, but for now they're just pulled down and extracted + copied.

I've tested this on my M1 MacBook Pro running macOS 14.6.1 (23G93), and it can - at the very least - program my Alchitry Cu with an iCE40.
It's unfortunately all I have to test with, so if anyone else can verify this I would be very grateful.
