### PR TITLE
Add yosys-slang

### DIFF
--- a/default/rules/default.py
+++ b/default/rules/default.py
@@ -10,6 +10,7 @@ Target(
         'imctk',
         'ghdl',
         'ghdl-yosys-plugin',
+        'yosys-slang-plugin',
         'nextpnr-generic',
         'nextpnr-ice40',
         'nextpnr-ecp5',

--- a/default/rules/yosys.py
+++ b/default/rules/yosys.py
@@ -17,6 +17,23 @@ SourceLocation(
 )
 
 SourceLocation(
+	name = 'slang',
+	vcs = 'git',
+	location = 'https://github.com/MikePopoloski/slang',
+	revision = 'origin/master',
+	license_file = 'LICENSE',
+	license_build_only = True,
+)
+
+SourceLocation(
+	name = 'yosys-slang-plugin',
+	vcs = 'git',
+	location = 'https://github.com/povik/yosys-slang',
+	revision = 'origin/master',
+	license_file = 'LICENSE',
+)
+
+SourceLocation(
 	name = 'graphviz',
 	vcs = 'git',
 	location = 'https://gitlab.com/graphviz/graphviz',
@@ -52,6 +69,20 @@ Target(
 	sources = [ 'ghdl-yosys-plugin' ],
 	dependencies = [ 'ghdl', 'yosys' ],
 	arch = [ 'linux-x64', 'darwin-x64', 'darwin-arm64' ],
+)
+
+Target(
+	name = 'slang',
+	sources = [ 'slang'],
+	build_native = True, # using this for license only
+	license_build_only = True,
+)
+
+Target(
+	name = 'yosys-slang-plugin',
+	sources = [ 'yosys-slang-plugin' ],
+	dependencies = [ 'yosys' ],
+	arch = [ 'linux-x64', 'linux-arm64', 'windows-x64' ],
 )
 
 SourceLocation(

--- a/default/scripts/yosys-slang-plugin.sh
+++ b/default/scripts/yosys-slang-plugin.sh
@@ -1,0 +1,8 @@
+cd yosys-slang-plugin
+sed -i 's/Windows.h/windows.h/g' third_party/slang/source/util/OS.cpp
+sed -i 's,/yosyshq/share,../yosys/yosyshq/share,g' ../yosys/yosyshq/bin/yosys-config
+sed -i 's,/yosyshq/include,../yosys/yosyshq/share/yosys/include,g' ../yosys/yosyshq/bin/yosys-config
+sed -i 's,/yosyshq/lib,../yosys/yosyshq/lib,g' ../yosys/yosyshq/bin/yosys-config
+make YOSYS_CONFIG=../yosys/yosyshq/bin/yosys-config
+mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}/share/yosys/plugins
+cp -rf build/slang.so ${OUTPUT_DIR}${INSTALL_PREFIX}/share/yosys/plugins/.


### PR DESCRIPTION
This is an attempt at getting yosys-slang into the Suite.

Compiling the plugin requires a recent compiler (clang 16 or GCC 11), so for linux-x64 I updated the builder image per @mmicko's instructions.

darwin-arm64 build is not working yet, so it's disabled, as well as darwin-x64.
