### PR TITLE
Fix `ghdl` builds on MacOS by bumping to `v6.0.0.`

### DIFF
--- a/default/scripts/ghdl-yosys-plugin.sh
+++ b/default/scripts/ghdl-yosys-plugin.sh
@@ -2,7 +2,7 @@ cd ghdl-yosys-plugin
 sed -i 's,/yosyshq/share,/yosys/yosyshq/share,g' ../yosys/yosyshq/bin/yosys-config
 if [ ${ARCH} == 'darwin-x64' ] || [ ${ARCH} == 'darwin-arm64' ]; then
     sed -i '11,13d' Makefile
-    make GHDL=../ghdl/yosyshq/bin/ghdl YOSYS_CONFIG=../yosys/yosyshq/bin/yosys-config CFLAGS="-I ../yosys/yosyshq/share/yosys/include" LIBGHDL_LIB="${BUILD_DIR}/ghdl${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib" LIBGHDL_INC="${BUILD_DIR}/ghdl${INSTALL_PREFIX}/include/"
+    make GHDL=../ghdl/yosyshq/bin/ghdl YOSYS_CONFIG=../yosys/yosyshq/bin/yosys-config CFLAGS="-I ../yosys/yosyshq/share/yosys/include" LIBGHDL_LIB="${BUILD_DIR}/ghdl${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib" LIBGHDL_INC="${BUILD_DIR}/ghdl${INSTALL_PREFIX}/include/"
 else
     make GHDL=../ghdl/yosyshq/bin/ghdl YOSYS_CONFIG=../yosys/yosyshq/bin/yosys-config CFLAGS="-I ../yosys/yosyshq/share/yosys/include"
 fi

--- a/default/scripts/ghdl.sh
+++ b/default/scripts/ghdl.sh
@@ -9,33 +9,33 @@ if [ ${ARCH} == 'linux-arm64' ]; then
     param=--with-llvm-config='llvm-config'
     LDFLAGS=-L/usr/lib/${CROSS_NAME}
 elif [ ${ARCH} == 'darwin-x64' ]; then
-    wget https://github.com/ghdl/ghdl/releases/download/nightly/ghdl-llvm-5.0.0-dev-macos13-x86_64.tar.gz
+    wget https://github.com/ghdl/ghdl/releases/download/nightly/ghdl-llvm-6.0.0-dev-macos13-x86_64.tar.gz
     mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}
-    tar xvfz ghdl-llvm-5.0.0-dev-macos13-x86_64.tar.gz -C ${OUTPUT_DIR}${INSTALL_PREFIX} --strip-components=1
-    install_name_tool -id @executable_path/../lib/libghdl-5_0_0_dev.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    tar xvfz ghdl-llvm-6.0.0-dev-macos13-x86_64.tar.gz -C ${OUTPUT_DIR}${INSTALL_PREFIX} --strip-components=1
+    install_name_tool -id @executable_path/../lib/libghdl-6_0_0_dev.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
     install_name_tool -id @executable_path/../lib/libghdlvpi.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdlvpi.dylib
     install_name_tool -id @executable_path/../lib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgnat-14.dylib
     install_name_tool -id @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgcc_s.1.1.dylib
-    install_name_tool -change @rpath/libgnat-14.dylib @executable_path/../lib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
-    install_name_tool -change @rpath/libgcc_s.1.1.dylib @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    install_name_tool -change @rpath/libgnat-14.dylib @executable_path/../lib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
+    install_name_tool -change @rpath/libgcc_s.1.1.dylib @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
     install_name_tool -change @rpath/libgcc_s.1.1.dylib @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgnat-14.dylib
-    rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
     rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdlvpi.dylib
     rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgnat-14.dylib
     rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgcc_s.1.1.dylib
     exit 0
 elif [ ${ARCH} == 'darwin-arm64' ]; then
-    wget https://github.com/ghdl/ghdl/releases/download/nightly/ghdl-llvm-5.0.0-dev-macos14-aarch64.tar.gz
+    wget https://github.com/ghdl/ghdl/releases/download/nightly/ghdl-llvm-6.0.0-dev-macos14-aarch64.tar.gz
     mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}
-    tar xvfz ghdl-llvm-5.0.0-dev-macos14-aarch64.tar.gz -C ${OUTPUT_DIR}${INSTALL_PREFIX} --strip-components=1
-    install_name_tool -id @executable_path/../lib/libghdl-5_0_0_dev.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    tar xvfz ghdl-llvm-6.0.0-dev-macos14-aarch64.tar.gz -C ${OUTPUT_DIR}${INSTALL_PREFIX} --strip-components=1
+    install_name_tool -id @executable_path/../lib/libghdl-6_0_0_dev.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
     install_name_tool -id @executable_path/../lib/libghdlvpi.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdlvpi.dylib
     install_name_tool -id @executable_path/../lib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgnat-14.dylib
     install_name_tool -id @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgcc_s.1.1.dylib
-    install_name_tool -change @rpath/libgnat-14.dylib @executable_path/../lib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
-    install_name_tool -change @rpath/libgcc_s.1.1.dylib @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    install_name_tool -change @rpath/libgnat-14.dylib @executable_path/../lib/libgnat-14.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
+    install_name_tool -change @rpath/libgcc_s.1.1.dylib @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
     install_name_tool -change @rpath/libgcc_s.1.1.dylib @executable_path/../lib/libgcc_s.1.1.dylib ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgnat-14.dylib
-    rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-5_0_0_dev.dylib
+    rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdl-6_0_0_dev.dylib
     rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libghdlvpi.dylib
     rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgnat-14.dylib
     rcodesign sign ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/libgcc_s.1.1.dylib


### PR DESCRIPTION
GHDL appears to have yanked the `5.0.0` tarballs, causing GHDL builds to fail on MacOS. This PR fixes that by bumping it to the latest version (`6.0.0`).