### PR TITLE
add support for using builder.py under macos-arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ ARM64 based Linux devices using 64bit CPU as in Raspberry Pi 4,5 and 400 (with 6
 
 ## Contributing
 
-To be able to build OSS CAD Suite yourself, you need to install `docker` (please note this only works on x64 platforms) and `python 3.6` or higher, with the `click` library.
+To be able to build OSS CAD Suite yourself, you need to install `docker` (please note this only works on x64 platforms or under rosetta on macos-arm) and `python 3.6` or higher, with the `click` library.
 
 
 After that just running ```./builder.py``` should work fine.

--- a/src/base.py
+++ b/src/base.py
@@ -419,6 +419,12 @@ def executeBuild(target, arch, prefix, build_dir, output_dir, nproc, pack_source
 		'-v', '{}:/work'.format(cwd),
 		'-w', os.path.join('/work', os.path.relpath(build_dir, os.getcwd())),
 	]
+
+	if not scriptfile.name.startswith("/tmp"):
+		params += ['-v', f'{scriptfile.name}:{scriptfile.name}']
+	if platform.system() == "Darwin" and platform.processor() == "arm":
+		params += ['--platform', 'linux/amd64']
+
 	for i, j in env.items():
 		if i.endswith('_DIR'):
 			params += ['-e', '{}={}'.format(i, os.path.join('/work', os.path.relpath(j, os.getcwd())))]


### PR DESCRIPTION
this uses rosetta for emulation but adds the required arguments to make it work.
