### PR TITLE
Enable xilinx uarch for nextpnr-himbaechel

### DIFF
--- a/.github/workflows/darwin-arm64.yml
+++ b/.github/workflows/darwin-arm64.yml
@@ -576,6 +576,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-gatemate-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-nextpnr-bba
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-nextpnr-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-xilinx-bba
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-xilinx-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python3-native
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Build
@@ -658,6 +660,45 @@ jobs:
           omitNameDuringUpdate: True
           tag: bucket-darwin-arm64
           artifacts: "darwin-arm64-prjtrellis.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
+  darwin-arm64-prjxray:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: darwin-arm64-python3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v4
+        with:
+          path: _sources
+          key: cache-sources-prjxray
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-arm64/darwin-arm64-prjxray.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download darwin-arm64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-arm64/darwin-arm64-python3.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-python3-native
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=darwin-arm64 --target=prjxray --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('darwin-arm64-prjxray.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-darwin-arm64
+          artifacts: "darwin-arm64-prjxray.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
   darwin-arm64-prjpeppercorn:
     runs-on: ubuntu-latest
@@ -1674,7 +1715,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   darwin-arm64-default:
     runs-on: ubuntu-latest
-    needs: [ darwin-arm64-aiger, darwin-arm64-apicula, darwin-arm64-avy, darwin-arm64-bitwuzla, darwin-arm64-boolector, darwin-arm64-cocotb, darwin-arm64-cvc4, darwin-arm64-cvc5, darwin-arm64-eqy, darwin-arm64-formal, darwin-arm64-ghdl, darwin-arm64-ghdl-yosys-plugin, darwin-arm64-graphviz, darwin-arm64-gtkwave, darwin-arm64-icestorm, darwin-arm64-imctk, darwin-arm64-iverilog, darwin-arm64-nextpnr-ecp5, darwin-arm64-nextpnr-generic, darwin-arm64-nextpnr-himbaechel, darwin-arm64-nextpnr-ice40, darwin-arm64-nextpnr-machxo2, darwin-arm64-nextpnr-nexus, darwin-arm64-openfpgaloader, darwin-arm64-pono, darwin-arm64-prjoxide, darwin-arm64-prjpeppercorn, darwin-arm64-prjtrellis, darwin-arm64-pyhdl, darwin-arm64-python-programmers, darwin-arm64-python3, darwin-arm64-system-resources, darwin-arm64-utils, darwin-arm64-verilator, darwin-arm64-xdot, darwin-arm64-yices, darwin-arm64-yosys, darwin-arm64-yosys-slang-plugin, darwin-arm64-z3 ]
+    needs: [ darwin-arm64-aiger, darwin-arm64-apicula, darwin-arm64-avy, darwin-arm64-bitwuzla, darwin-arm64-boolector, darwin-arm64-cocotb, darwin-arm64-cvc4, darwin-arm64-cvc5, darwin-arm64-eqy, darwin-arm64-formal, darwin-arm64-ghdl, darwin-arm64-ghdl-yosys-plugin, darwin-arm64-graphviz, darwin-arm64-gtkwave, darwin-arm64-icestorm, darwin-arm64-imctk, darwin-arm64-iverilog, darwin-arm64-nextpnr-ecp5, darwin-arm64-nextpnr-generic, darwin-arm64-nextpnr-himbaechel, darwin-arm64-nextpnr-ice40, darwin-arm64-nextpnr-machxo2, darwin-arm64-nextpnr-nexus, darwin-arm64-openfpgaloader, darwin-arm64-pono, darwin-arm64-prjoxide, darwin-arm64-prjpeppercorn, darwin-arm64-prjtrellis, darwin-amd64-prjxray, darwin-arm64-pyhdl, darwin-arm64-python-programmers, darwin-arm64-python3, darwin-arm64-system-resources, darwin-arm64-utils, darwin-arm64-verilator, darwin-arm64-xdot, darwin-arm64-yices, darwin-arm64-yosys, darwin-arm64-yosys-slang-plugin, darwin-arm64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1738,6 +1779,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-arm64/darwin-arm64-prjpeppercorn.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download darwin-arm64-prjtrellis
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-arm64/darwin-arm64-prjtrellis.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download darwin-arm64-prjxray
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-arm64/darwin-arm64-prjxray.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download darwin-arm64-pyhdl
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-arm64/darwin-arm64-pyhdl.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download darwin-arm64-python-programmers

--- a/.github/workflows/darwin-x64.yml
+++ b/.github/workflows/darwin-x64.yml
@@ -576,6 +576,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-gatemate-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-nextpnr-bba
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-nextpnr-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-xilinx-bba
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-xilinx-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python3-native
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Build
@@ -658,6 +660,45 @@ jobs:
           omitNameDuringUpdate: True
           tag: bucket-darwin-x64
           artifacts: "darwin-x64-prjtrellis.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
+  darwin-x64-prjxray:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: darwin-x64-python3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v4
+        with:
+          path: _sources
+          key: cache-sources-prjxray
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-prjxray.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download darwin-x64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-python3.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-python3-native
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=darwin-x64 --target=prjxray --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('darwin-x64-prjxray.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-darwin-x64
+          artifacts: "darwin-x64-prjxray.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
   darwin-x64-prjpeppercorn:
     runs-on: ubuntu-latest
@@ -1674,7 +1715,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   darwin-x64-default:
     runs-on: ubuntu-latest
-    needs: [ darwin-x64-aiger, darwin-x64-apicula, darwin-x64-avy, darwin-x64-bitwuzla, darwin-x64-boolector, darwin-x64-cocotb, darwin-x64-cvc4, darwin-x64-cvc5, darwin-x64-eqy, darwin-x64-formal, darwin-x64-ghdl, darwin-x64-ghdl-yosys-plugin, darwin-x64-graphviz, darwin-x64-gtkwave, darwin-x64-icestorm, darwin-x64-imctk, darwin-x64-iverilog, darwin-x64-nextpnr-ecp5, darwin-x64-nextpnr-generic, darwin-x64-nextpnr-himbaechel, darwin-x64-nextpnr-ice40, darwin-x64-nextpnr-machxo2, darwin-x64-nextpnr-nexus, darwin-x64-openfpgaloader, darwin-x64-pono, darwin-x64-prjoxide, darwin-x64-prjpeppercorn, darwin-x64-prjtrellis, darwin-x64-pyhdl, darwin-x64-python-programmers, darwin-x64-python3, darwin-x64-system-resources, darwin-x64-utils, darwin-x64-verilator, darwin-x64-xdot, darwin-x64-yices, darwin-x64-yosys, darwin-x64-yosys-slang-plugin, darwin-x64-z3 ]
+    needs: [ darwin-x64-aiger, darwin-x64-apicula, darwin-x64-avy, darwin-x64-bitwuzla, darwin-x64-boolector, darwin-x64-cocotb, darwin-x64-cvc4, darwin-x64-cvc5, darwin-x64-eqy, darwin-x64-formal, darwin-x64-ghdl, darwin-x64-ghdl-yosys-plugin, darwin-x64-graphviz, darwin-x64-gtkwave, darwin-x64-icestorm, darwin-x64-imctk, darwin-x64-iverilog, darwin-x64-nextpnr-ecp5, darwin-x64-nextpnr-generic, darwin-x64-nextpnr-himbaechel, darwin-x64-nextpnr-ice40, darwin-x64-nextpnr-machxo2, darwin-x64-nextpnr-nexus, darwin-x64-openfpgaloader, darwin-x64-pono, darwin-x64-prjoxide, darwin-x64-prjpeppercorn, darwin-x64-prjtrellis, darwin-x64-prjxray, darwin-x64-pyhdl, darwin-x64-python-programmers, darwin-x64-python3, darwin-x64-system-resources, darwin-x64-utils, darwin-x64-verilator, darwin-x64-xdot, darwin-x64-yices, darwin-x64-yosys, darwin-x64-yosys-slang-plugin, darwin-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1738,6 +1779,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-prjpeppercorn.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download darwin-x64-prjtrellis
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-prjtrellis.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download darwin-x64-prjxray
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-prjxray.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download darwin-x64-pyhdl
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-darwin-x64/darwin-x64-pyhdl.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download darwin-x64-python-programmers

--- a/.github/workflows/linux-arm64.yml
+++ b/.github/workflows/linux-arm64.yml
@@ -503,6 +503,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-gatemate-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-nextpnr-bba
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-nextpnr-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-xilinx-bba
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-xilinx-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python3-native
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Build
@@ -585,6 +587,45 @@ jobs:
           omitNameDuringUpdate: True
           tag: bucket-linux-arm64
           artifacts: "linux-arm64-prjtrellis.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
+  linux-arm64-prjxray:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: linux-arm64-python3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v4
+        with:
+          path: _sources
+          key: cache-sources-prjxray
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-prjxray.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-arm64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-python3.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-python3-native
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-arm64 --target=prjxray --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-arm64-prjxray.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-arm64
+          artifacts: "linux-arm64-prjxray.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-arm64-prjpeppercorn:
     runs-on: ubuntu-latest
@@ -1674,7 +1715,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-arm64-default:
     runs-on: ubuntu-latest
-    needs: [ linux-arm64-aiger, linux-arm64-apicula, linux-arm64-avy, linux-arm64-bitwuzla, linux-arm64-boolector, linux-arm64-cocotb, linux-arm64-cvc4, linux-arm64-cvc5, linux-arm64-eqy, linux-arm64-formal, linux-arm64-graphviz, linux-arm64-gtkwave, linux-arm64-icestorm, linux-arm64-imctk, linux-arm64-iverilog, linux-arm64-nextpnr-ecp5, linux-arm64-nextpnr-generic, linux-arm64-nextpnr-himbaechel, linux-arm64-nextpnr-ice40, linux-arm64-nextpnr-machxo2, linux-arm64-nextpnr-nexus, linux-arm64-openfpgaloader, linux-arm64-pono, linux-arm64-prjoxide, linux-arm64-prjpeppercorn, linux-arm64-prjtrellis, linux-arm64-pyhdl, linux-arm64-python-programmers, linux-arm64-python2, linux-arm64-python3, linux-arm64-suprove, linux-arm64-system-resources, linux-arm64-utils, linux-arm64-verilator, linux-arm64-xdot, linux-arm64-yices, linux-arm64-yosys, linux-arm64-yosys-slang-plugin, linux-arm64-z3 ]
+    needs: [ linux-arm64-aiger, linux-arm64-apicula, linux-arm64-avy, linux-arm64-bitwuzla, linux-arm64-boolector, linux-arm64-cocotb, linux-arm64-cvc4, linux-arm64-cvc5, linux-arm64-eqy, linux-arm64-formal, linux-arm64-graphviz, linux-arm64-gtkwave, linux-arm64-icestorm, linux-arm64-imctk, linux-arm64-iverilog, linux-arm64-nextpnr-ecp5, linux-arm64-nextpnr-generic, linux-arm64-nextpnr-himbaechel, linux-arm64-nextpnr-ice40, linux-arm64-nextpnr-machxo2, linux-arm64-nextpnr-nexus, linux-arm64-openfpgaloader, linux-arm64-pono, linux-arm64-prjoxide, linux-arm64-prjpeppercorn, linux-arm64-prjtrellis, linux-arm64-prjxray, linux-arm64-pyhdl, linux-arm64-python-programmers, linux-arm64-python2, linux-arm64-python3, linux-arm64-suprove, linux-arm64-system-resources, linux-arm64-utils, linux-arm64-verilator, linux-arm64-xdot, linux-arm64-yices, linux-arm64-yosys, linux-arm64-yosys-slang-plugin, linux-arm64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1734,6 +1775,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-prjpeppercorn.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-arm64-prjtrellis
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-prjtrellis.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-arm64-prjxray
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-prjxray.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-arm64-pyhdl
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-arm64/linux-arm64-pyhdl.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-arm64-python-programmers

--- a/.github/workflows/linux-x64.yml
+++ b/.github/workflows/linux-x64.yml
@@ -939,10 +939,47 @@ jobs:
           tag: bucket-linux-x64
           artifacts: "linux-x64-gatemate-bba.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  linux-x64-xilinx-bba:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: linux-x64-python3-native
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v4
+        with:
+          path: _sources
+          key: cache-sources-xilinx-bba
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-xilinx-bba.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-x64-python3-native
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-x64 --target=xilinx-bba --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-x64-xilinx-bba.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-x64
+          artifacts: "linux-x64-xilinx-bba.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-nextpnr-himbaechel:
     runs-on: ubuntu-latest
     continue-on-error: true
-    needs: [ linux-x64-apicula-bba, linux-x64-gatemate-bba, linux-x64-nextpnr-bba, linux-x64-python3, linux-x64-python3-native ]
+    needs: [ linux-x64-apicula-bba, linux-x64-gatemate-bba, linux-x64-nextpnr-bba, linux-x64-xilinx-bba, linux-x64-python3, linux-x64-python3-native ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -967,6 +1004,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-gatemate-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-nextpnr-bba
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-nextpnr-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-xilinx-bba
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-xilinx-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python3
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python3-native
@@ -1017,6 +1056,45 @@ jobs:
           omitNameDuringUpdate: True
           tag: bucket-linux-x64
           artifacts: "linux-x64-prjtrellis.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
+  linux-x64-prjxray:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [ linux-x64-python3, linux-x64-python3-native ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v4
+        with:
+          path: _sources
+          key: cache-sources-prjxray
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-prjxray.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-x64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-python3-native
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=linux-x64 --target=prjxray --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-x64-prjxray.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-x64
+          artifacts: "linux-x64-prjxray.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-prjpeppercorn:
     runs-on: ubuntu-latest
@@ -2102,7 +2180,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-default:
     runs-on: ubuntu-latest
-    needs: [ linux-x64-aiger, linux-x64-apicula, linux-x64-avy, linux-x64-bitwuzla, linux-x64-boolector, linux-x64-cocotb, linux-x64-cvc4, linux-x64-cvc5, linux-x64-eqy, linux-x64-formal, linux-x64-ghdl, linux-x64-ghdl-yosys-plugin, linux-x64-graphviz, linux-x64-gtkwave, linux-x64-icestorm, linux-x64-imctk, linux-x64-iverilog, linux-x64-nextpnr-ecp5, linux-x64-nextpnr-generic, linux-x64-nextpnr-himbaechel, linux-x64-nextpnr-ice40, linux-x64-nextpnr-machxo2, linux-x64-nextpnr-nexus, linux-x64-openfpgaloader, linux-x64-pono, linux-x64-prjoxide, linux-x64-prjpeppercorn, linux-x64-prjtrellis, linux-x64-pyhdl, linux-x64-python-programmers, linux-x64-python2, linux-x64-python3, linux-x64-suprove, linux-x64-system-resources, linux-x64-utils, linux-x64-verilator, linux-x64-xdot, linux-x64-yices, linux-x64-yosys, linux-x64-yosys-slang-plugin, linux-x64-z3 ]
+    needs: [ linux-x64-aiger, linux-x64-apicula, linux-x64-avy, linux-x64-bitwuzla, linux-x64-boolector, linux-x64-cocotb, linux-x64-cvc4, linux-x64-cvc5, linux-x64-eqy, linux-x64-formal, linux-x64-ghdl, linux-x64-ghdl-yosys-plugin, linux-x64-graphviz, linux-x64-gtkwave, linux-x64-icestorm, linux-x64-imctk, linux-x64-iverilog, linux-x64-nextpnr-ecp5, linux-x64-nextpnr-generic, linux-x64-nextpnr-himbaechel, linux-x64-nextpnr-ice40, linux-x64-nextpnr-machxo2, linux-x64-nextpnr-nexus, linux-x64-openfpgaloader, linux-x64-pono, linux-x64-prjoxide, linux-x64-prjpeppercorn, linux-x64-prjtrellis, linux-x64-prjxray, linux-x64-pyhdl, linux-x64-python-programmers, linux-x64-python2, linux-x64-python3, linux-x64-suprove, linux-x64-system-resources, linux-x64-utils, linux-x64-verilator, linux-x64-xdot, linux-x64-yices, linux-x64-yosys, linux-x64-yosys-slang-plugin, linux-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -2166,6 +2244,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-prjpeppercorn.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-prjtrellis
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-prjtrellis.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-prjxray
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-prjxray.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-pyhdl
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-pyhdl.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python-programmers

--- a/.github/workflows/windows-x64.yml
+++ b/.github/workflows/windows-x64.yml
@@ -428,6 +428,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-gatemate-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-nextpnr-bba
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-nextpnr-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-xilinx-bba
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-xilinx-bba.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-python3-native
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download windows-x64-python3
@@ -512,6 +514,45 @@ jobs:
           omitNameDuringUpdate: True
           tag: bucket-windows-x64
           artifacts: "windows-x64-prjtrellis.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
+  windows-x64-prjxray:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: windows-x64-python3
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: 'yosyshq/oss-cad-suite-build'
+      - name: Cache sources
+        id: cache-sources
+        uses: actions/cache@v4
+        with:
+          path: _sources
+          key: cache-sources-prjxray
+      - name: Download previous build
+        run: |
+          URL="https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-prjxray.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Download linux-x64-python3-native
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-linux-x64/linux-x64-python3-native.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download windows-x64-python3
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-python3.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Build
+        run: ./builder.py build --arch=windows-x64 --target=prjxray --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('windows-x64-prjxray.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-windows-x64
+          artifacts: "windows-x64-prjxray.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
   windows-x64-prjpeppercorn:
     runs-on: ubuntu-latest
@@ -1379,7 +1420,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   windows-x64-default:
     runs-on: ubuntu-latest
-    needs: [ windows-x64-apicula, windows-x64-avy, windows-x64-bitwuzla, windows-x64-boolector, windows-x64-cvc4, windows-x64-cvc5, windows-x64-eqy, windows-x64-formal, windows-x64-gtkwave, windows-x64-icestorm, windows-x64-imctk, windows-x64-iverilog, windows-x64-nextpnr-ecp5, windows-x64-nextpnr-generic, windows-x64-nextpnr-himbaechel, windows-x64-nextpnr-ice40, windows-x64-nextpnr-machxo2, windows-x64-nextpnr-nexus, windows-x64-openfpgaloader, windows-x64-pono, windows-x64-prjoxide, windows-x64-prjpeppercorn, windows-x64-prjtrellis, windows-x64-pyhdl, windows-x64-python3, windows-x64-system-resources, windows-x64-utils, windows-x64-verilator, windows-x64-yices, windows-x64-yosys, windows-x64-yosys-slang-plugin, windows-x64-z3 ]
+    needs: [ windows-x64-apicula, windows-x64-avy, windows-x64-bitwuzla, windows-x64-boolector, windows-x64-cvc4, windows-x64-cvc5, windows-x64-eqy, windows-x64-formal, windows-x64-gtkwave, windows-x64-icestorm, windows-x64-imctk, windows-x64-iverilog, windows-x64-nextpnr-ecp5, windows-x64-nextpnr-generic, windows-x64-nextpnr-himbaechel, windows-x64-nextpnr-ice40, windows-x64-nextpnr-machxo2, windows-x64-nextpnr-nexus, windows-x64-openfpgaloader, windows-x64-pono, windows-x64-prjoxide, windows-x64-prjpeppercorn, windows-x64-prjtrellis, windows-x64-prjxray, windows-x64-pyhdl, windows-x64-python3, windows-x64-system-resources, windows-x64-utils, windows-x64-verilator, windows-x64-yices, windows-x64-yosys, windows-x64-yosys-slang-plugin, windows-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -1433,6 +1474,8 @@ jobs:
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-prjpeppercorn.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download windows-x64-prjtrellis
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-prjtrellis.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download windows-x64-prjxray
+        run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-prjxray.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download windows-x64-pyhdl
         run: wget -qO- "https://github.com/yosyshq/oss-cad-suite-build/releases/download/bucket-windows-x64/windows-x64-pyhdl.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download windows-x64-python3

--- a/default/rules/default.py
+++ b/default/rules/default.py
@@ -21,6 +21,7 @@ Target(
         'prjtrellis',
         'prjpeppercorn',
         'prjoxide',
+        'prjxray',
         'apicula',
         'openfpgaloader',
         'aiger',

--- a/default/rules/nextpnr.py
+++ b/default/rules/nextpnr.py
@@ -65,7 +65,7 @@ Target(
 Target(
 	name = 'nextpnr-himbaechel',
 	sources = [ 'nextpnr' ],
-	dependencies = [ 'python3', 'nextpnr-bba', 'apicula-bba', 'gatemate-bba', 'python3-native'],
+	dependencies = [ 'python3', 'nextpnr-bba', 'apicula-bba', 'gatemate-bba', 'xilinx-bba', 'python3-native'],
 	patches = [ 'python3_package.sh' ],
 	resources = [ 'python3' ],
 )
@@ -119,6 +119,22 @@ SourceLocation(
 	license_file = 'COPYING',
 )
 
+SourceLocation(
+	name = 'prjxray',
+	vcs = 'git',
+	location = 'https://github.com/f4pga/prjxray',
+	revision = 'origin/master',
+	license_file = 'LICENSE',
+)
+
+SourceLocation(
+	name = 'prjxray-db',
+	vcs = 'git',
+	location = 'https://github.com/f4pga/prjxray-db',
+	revision = 'origin/master',
+	license_file = 'LICENSE',
+)
+
 Target(
 	name = 'icestorm',
 	sources = [ 'icestorm' ],
@@ -149,6 +165,14 @@ Target(
 	name = 'prjpeppercorn',
 	sources = [ 'prjpeppercorn' ],
 	package = 'gatemate',
+)
+
+Target(
+	name = 'prjxray',
+	sources = [ 'prjxray', 'prjxray-db' ],
+	dependencies = [ 'python3', 'python3-native' ],
+	resources = [ 'python3' ],
+	package = 'xilinx',
 )
 
 # chip databases
@@ -188,6 +212,14 @@ Target(
 Target(
 	name = 'gatemate-bba',
 	sources = [ 'nextpnr', 'prjpeppercorn' ],
+	dependencies = ['python3-native'],
+	gitrev = [ ('nextpnr', 'himbaechel') ],
+	build_native = True,
+)
+
+Target(
+	name = 'xilinx-bba',
+	sources = [ 'nextpnr', 'prjxray-db' ],
 	dependencies = ['python3-native'],
 	gitrev = [ ('nextpnr', 'himbaechel') ],
 	build_native = True,

--- a/default/scripts/nextpnr-himbaechel.sh
+++ b/default/scripts/nextpnr-himbaechel.sh
@@ -3,6 +3,7 @@ cd nextpnr
 mkdir bba-files
 cp -rf ${BUILD_DIR}/apicula-bba/bba-files/* bba-files/.
 cp -rf ${BUILD_DIR}/gatemate-bba/bba-files/* bba-files/.
+cp -rf ${BUILD_DIR}/xilinx-bba/bba-files/* bba-files/.
 build_gui="OFF"
 if [ ${ARCH} == 'linux-x64' ] || [ ${ARCH} == 'windows-x64' ] || [ ${ARCH} == 'darwin-x64' ] || [ ${ARCH} == 'darwin-arm64' ]; then
       build_gui="ON"
@@ -10,7 +11,7 @@ fi
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
       -DPython3_INCLUDE_DIR=${BUILD_DIR}/python3${INSTALL_PREFIX}/include/python3.11 \
       -DPython3_LIBRARY=${BUILD_DIR}/python3${INSTALL_PREFIX}/lib/libpython3.11${SHARED_EXT} \
-      -DARCH=himbaechel -DHIMBAECHEL_UARCH="gowin;gatemate" \
+      -DARCH=himbaechel -DHIMBAECHEL_UARCH="gowin;gatemate;xilinx" \
       -DIMPORT_BBA_FILES=${BUILD_DIR}/nextpnr/bba-files \
       -DBUILD_GUI=${build_gui} -DUSE_IPO=OFF \
       -DBBA_IMPORT=${BUILD_DIR}/nextpnr-bba/nextpnr/bba/bba-export.cmake \

--- a/default/scripts/prjxray.sh
+++ b/default/scripts/prjxray.sh
@@ -1,0 +1,18 @@
+mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}/share/xray
+cp -r prjxray-db ${OUTPUT_DIR}${INSTALL_PREFIX}/share/xray/database
+
+cd prjxray
+source ${PATCHES_DIR}/python3_package.sh
+mv utils/fasm2frames.py prjxray/.
+sed -E 's/(fasm2frames=)utils/\1prjxray/' -i setup.py
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
+      -B build
+make -C build DESTDIR=${OUTPUT_DIR} -j${NPROC} install
+python3_package_setup
+# Technically numpy is also a dependency, but it looks like it is not used
+# during the build process nor by any installed artifacts.
+for dep in fasm intervaltree pyjson5 pyyaml simplejson; do
+    python3_package_pip_install ${dep}
+done
+python3_package_install --old-and-unmanageable

--- a/default/scripts/xilinx-bba.sh
+++ b/default/scripts/xilinx-bba.sh
@@ -1,0 +1,10 @@
+cd nextpnr
+cmake -DXilinxChipdb_Python3_EXECUTABLE=${BUILD_DIR}/python3-native${INSTALL_PREFIX}/bin/python3.11 \
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
+      -DARCH=himbaechel -DHIMBAECHEL_UARCH=xilinx \
+      -DHIMBAECHEL_XILINX_DEVICES=all \
+      -DHIMBAECHEL_PRJXRAY_DB=${BUILD_DIR}/prjxray-db \
+      -DEXPORT_BBA_FILES=${OUTPUT_DIR}/bba-files \
+      -B build
+
+make -C build nextpnr-all-bba


### PR DESCRIPTION
This PR enables support for the Xilinx uarch in `nextpnr-himbaechel`. It builds the required tools from [f4pga/prjxray](https://github.com/f4pga/prjxray), but makes use of the prebuilt [f4pga/prjxray-db](https://github.com/f4pga/prjxray-db) chip database.

I've tested these changes on the `linux-x64` workflow and it adds the following build time and tarball size to it:

- 20m 2s ⟶ 30m 49s
- 647 MB ⟶ 751 MB

**NOTE:** the increase in time may be caused by having to rebuild everything from scratch. I'll update this comment when I have better data.

There were some concerns raised on #85 about the increase in build time and tarball size, and I originally planned to keep these changes on a private fork, but I decided to send a PR for the record.

Depends on [nextpnr#1509](https://github.com/YosysHQ/nextpnr/pull/1509).

~There is a problem with the installed `fasm2frames` tool: it doesn't work properly for some reason I fail to understand at the time of writing.~ Fixed by adding missing line from the source (thanks Arch User Repository)
