### PR TITLE
Add Surfer

### DIFF
--- a/default/rules/waveformviewers.py
+++ b/default/rules/waveformviewers.py
@@ -13,3 +13,17 @@ Target(
 	sources = [ 'gtkwave' ],
 	package = 'gtkwave',
 )
+
+SourceLocation(
+	name = 'surfer',
+	vcs = 'git',
+	location = 'https://gitlab.com/surfer-project/surfer',
+	revision = 'origin/main',
+	license_file = 'LICENSE-EUPL-1.2.txt',
+)
+
+Target(
+	name = 'surfer',
+	sources = [ 'surfer' ],
+	package = 'surfer',
+)

--- a/default/scripts/surfer.sh
+++ b/default/scripts/surfer.sh
@@ -1,0 +1,2 @@
+cargo install --no-track --locked --root ${OUTPUT_DIR}${INSTALL_PREFIX} --target=${CARGO_TARGET} --path ./surfer/surfer
+cargo install --no-track --locked --root ${OUTPUT_DIR}${INSTALL_PREFIX} --target=${CARGO_TARGET} --path ./surfer/surver


### PR DESCRIPTION
We've had requests to add the Surfer waveform viewer to OSS CAD Suite, so here goes. No idea if it works, but at least looks promising locally.

Based on discussions with @mattvenn I can inform that the pre-built Linux binary that we offer is 15.5 MB and surver 1 MB (the remote server version). I think this should provide both.

Surfer requires Rust 1.82 and there may be openSSL issues as with #155, but we do not explicitly require any give version, but maybe the crate that we are using does.