### PR TITLE
Enable libyosys

### DIFF
--- a/default/scripts/yosys.sh
+++ b/default/scripts/yosys.sh
@@ -13,7 +13,7 @@ else
 	make config-gcc
 	sed -i -re "s,CXX = g\+\+,CXX = ${CXX},g" Makefile
 fi
-make PREFIX=${INSTALL_PREFIX} DESTDIR=${OUTPUT_DIR} install -j${NPROC}
+make PREFIX=${INSTALL_PREFIX} DESTDIR=${OUTPUT_DIR} ENABLE_LIBYOSYS=1 install -j${NPROC}
 pushd ${OUTPUT_DIR}${INSTALL_PREFIX} 
 if [ ${ARCH} != 'windows-x64' ]; then
 	mkdir -p lib


### PR DESCRIPTION
Adds `ENABLE_LIBYOSYS=1` flag for building the Yosys shared library. Incurs minimal compilation overhead and allows users to directly link to Yosys.