### PR TITLE
Upgrade to Ubuntu 24 04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@
 /_builds
 /__pycache__
 .vscode/
+
+# Vim Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python3 litex_setup.py install
 
 ### linux-x64
 Any personal Linux based computer should just work; no additional packages need to be installed on the system to make OSS CAD Suite work.
-Distributed libraries are based on Ubuntu 20.04, but everything is packaged in such a way so it can be used on any Linux distribution.
+Distributed libraries are based on Ubuntu 24.04, but everything is packaged in such a way so it can be used on any Linux distribution.
 
 ### darwin-x64
 Any macOS 12.00 or later with Intel CPU should use this distribution package.

--- a/default/rules/solvers.py
+++ b/default/rules/solvers.py
@@ -154,7 +154,7 @@ SourceLocation(
 	name = 'libpoly',
 	vcs = 'git',
 	location = 'https://github.com/SRI-CSL/libpoly',
-	revision = '1383809f2aa5005ef20110fec84b66959518f697',
+	revision = 'fc54e31f37cbdb5fc72416ad1c2b5e44551ccd7f',
 	license_file = 'LICENCE',
 	license_build_only = True,
 )

--- a/default/rules/solvers.py
+++ b/default/rules/solvers.py
@@ -118,8 +118,8 @@ Target(
 SourceLocation(
 	name = 'smt-switch',
 	vcs = 'git',
-	location = 'https://github.com/makaimann/smt-switch',
-	revision = 'f2d7d3d6dfccc0b4d6b604563acd34629bac884d',
+	location = 'https://github.com/stanford-centaur/smt-switch',
+	revision = '758e9e125dd76bc72b39add7adf8332992c0c527',
 	license_file = 'LICENSE',
 	license_build_only = True,
 )
@@ -182,7 +182,7 @@ Target(
 Target(
 	name = 'smt-switch',
 	sources = [ 'smt-switch' ],
-	dependencies = [ 'cvc5', 'boolector'],
+	dependencies = [ 'cvc5', 'boolector', 'cadical'],
 	patches = [ 'smt-switch-win32.diff', 'Toolchain-mingw64.cmake' ],
 	license_build_only = True,
 )

--- a/default/rules/solvers.py
+++ b/default/rules/solvers.py
@@ -145,7 +145,7 @@ SourceLocation(
 	name = 'cvc5',
 	vcs = 'git',
 	location = 'https://github.com/cvc5/cvc5',
-	revision = '77d0bec48a745e3c4acd65085f9c59bdfceed6c0',
+	revision = '435f2d44f1bb37c4c17d2b59615b7323039b7a62',
 	license_file = 'COPYING',
 	license_build_only = True,
 )

--- a/default/rules/solvers.py
+++ b/default/rules/solvers.py
@@ -135,8 +135,8 @@ SourceLocation(
 SourceLocation(
 	name = 'cvc4',
 	vcs = 'git',
-	location = 'https://github.com/CVC4/CVC4.git',
-	revision = '3dda54ba7e6952060766775c56969ab920430a8a',
+	location = 'https://github.com/cvc5/cvc5',
+	revision = '5247901077efbc7b9016ba35fded7a6ab459a379',
 	license_file = 'COPYING',
 	license_build_only = True,
 )

--- a/default/rules/solvers.py
+++ b/default/rules/solvers.py
@@ -38,7 +38,7 @@ SourceLocation(
 	name = 'bitwuzla',
 	vcs = 'git',
 	location = 'https://github.com/bitwuzla/bitwuzla',
-	revision = '6e46391816b4baf8c9fc0b8c0c1d2fbe63b6f30e',
+	revision = '532ca9729136969008960481167ab55696a9cc52',
 	license_file = 'COPYING',
 )
 
@@ -127,8 +127,8 @@ SourceLocation(
 SourceLocation(
 	name = 'pono',
 	vcs = 'git',
-	location = 'https://github.com/upscale-project/pono',
-	revision = 'b243cef7ea0c98840e7e012f5ce30f3430b1edcc',
+    location = 'https://github.com/stanford-centaur/pono',
+	revision = 'd307bc1539992275c74b594968c91967abeafe17',
 	license_file = 'LICENSE',
 )
 
@@ -182,7 +182,7 @@ Target(
 Target(
 	name = 'smt-switch',
 	sources = [ 'smt-switch' ],
-	dependencies = [ 'cvc5', 'boolector', 'cadical'],
+	dependencies = [ 'cvc5', 'boolector', 'cadical', 'bitwuzla'],
 	patches = [ 'smt-switch-win32.diff', 'Toolchain-mingw64.cmake' ],
 	license_build_only = True,
 )
@@ -190,7 +190,7 @@ Target(
 Target(
 	name = 'pono',
 	sources = [ 'pono' ],
-	dependencies = [ 'smt-switch', 'cvc5', 'boolector' ],
+	dependencies = [ 'smt-switch', 'cvc5', 'boolector', 'bitwuzla' ],
 )
 
 # suprove

--- a/default/rules/utils.py
+++ b/default/rules/utils.py
@@ -63,7 +63,7 @@ SourceLocation(
 SourceLocation(
 	name = 'openocd',
 	vcs = 'git',
-	location = 'https://repo.or.cz/openocd.git',
+    location = 'https://git.code.sf.net/p/openocd/code',
 	revision = 'b6ee13720688a9860f3397bb89ea171b0fc5ccce',
 	license_file = 'COPYING',
 )

--- a/default/scripts/bitwuzla.sh
+++ b/default/scripts/bitwuzla.sh
@@ -4,16 +4,27 @@ cp -r cadical/${INSTALL_PREFIX}/* bitwuzla/deps/install/.
 cp -r lingeling/${INSTALL_PREFIX}/* bitwuzla/deps/install/.
 cp -r symfpu/${INSTALL_PREFIX}/* bitwuzla/deps/install/.
 
+python3 -m venv meson_env
+source meson_env/bin/activate
+
+pip install --upgrade pip
+pip install meson ninja
+
 cd bitwuzla
 
-# Build Bitwuzla
-sed -i -re "s,cmake ..,cmake .. -DCMAKE_TOOLCHAIN_FILE=\${CMAKE_TOOLCHAIN_FILE},g" ./configure.sh
 if [ ${ARCH_BASE} == 'windows' ]; then
     export CMAKE_TOOLCHAIN_FILE=${PATCHES_DIR}/Toolchain-mingw64.cmake
 fi
-./configure.sh --prefix ${INSTALL_PREFIX} -fPIC
+./configure.py --prefix "/"
 cd build 
-make DESTDIR=${OUTPUT_DIR} -j${NPROC} install
+DESTDIR=${OUTPUT_DIR}${INSTALL_PREFIX} ninja -j${NPROC} install
+mkdir ${OUTPUT_DIR}/dev
+cp -r ${OUTPUT_DIR}${INSTALL_PREFIX}/include ${OUTPUT_DIR}/dev/include
+cp -r  ${OUTPUT_DIR}${INSTALL_PREFIX}/lib ${OUTPUT_DIR}/dev/lib
 # Do not expose includes and libs in final package
 rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/include
 rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/lib
+
+cd ../../
+deactivate
+rm -rf meson_env

--- a/default/scripts/boolector.sh
+++ b/default/scripts/boolector.sh
@@ -25,13 +25,13 @@ mkdir -p ${OUTPUT_DIR}/dev
 mkdir -p ${OUTPUT_DIR}/dev/build/lib
 mkdir -p ${OUTPUT_DIR}/dev/deps/lingeling/build
 mkdir -p ${OUTPUT_DIR}/dev/deps/cadical/build
-mkdir -p ${OUTPUT_DIR}/dev/deps/btor2tools/build
+mkdir -p ${OUTPUT_DIR}/dev/deps/btor2tools/build/lib
 mkdir -p ${OUTPUT_DIR}/dev/deps/btor2tools/src/btor2parser
 cp -r src ${OUTPUT_DIR}/dev/.
 cp -r build/lib/libboolector.a ${OUTPUT_DIR}/dev/build/lib/libboolector.a
 cp -r deps/install/lib/liblgl.a ${OUTPUT_DIR}/dev/deps/lingeling/build/liblgl.a
 cp -r deps/install/lib/libcadical.a ${OUTPUT_DIR}/dev/deps/cadical/build/libcadical.a
-cp -r deps/install/lib/libbtor2parser.a ${OUTPUT_DIR}/dev/deps/btor2tools/build/libbtor2parser.a
+cp -r deps/install/lib/libbtor2parser.a ${OUTPUT_DIR}/dev/deps/btor2tools/build/lib/libbtor2parser.a
 cp -r deps/install/include/btor2parser.h ${OUTPUT_DIR}/dev/deps/btor2tools/src/btor2parser/btor2parser.h
 # Do not expose includes and libs in final package
 rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/include

--- a/default/scripts/cvc4.sh
+++ b/default/scripts/cvc4.sh
@@ -1,29 +1,75 @@
+if [ -z "$__BASH500_BOOTSTRAPPED" ]; then
+  set -eu
+
+  export __BASH500_BOOTSTRAPPED=1
+  : "${BASH_500_PREFIX:="$(mktemp -d /tmp/bash-5.0.XXXXXXXX)"}"
+  : "${BASH_500_VERSION:=5.0}"
+  : "${BASH_500_TARBALL:=bash-${BASH_500_VERSION}.tar.gz}"
+  : "${BASH_500_URL:=https://ftp.gnu.org/gnu/bash/${BASH_500_TARBALL}}"
+
+  if command -v apt-get >/dev/null 2>&1 && [ "$(id -u)" -eq 0 ]; then
+    apt-get update -y >/dev/null 2>&1 || true
+    apt-get install -y build-essential wget curl libncurses-dev >/dev/null 2>&1 || true
+  fi
+
+  tmpbuild="$(mktemp -d /tmp/bash-5.0-src.XXXXXXXX)"
+  (
+    set -e
+    cd "$tmpbuild"
+    if command -v wget >/dev/null 2>&1; then
+      wget -q "$BASH_500_URL"
+    else
+      curl -fsSL -o "$BASH_500_TARBALL" "$BASH_500_URL"
+    fi
+    tar xzf "$BASH_500_TARBALL"
+    cd "bash-${BASH_500_VERSION}"
+    ./configure --prefix="$BASH_500_PREFIX" >/dev/null
+    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)" >/dev/null
+    make install >/dev/null
+  )
+  rm -rf "$tmpbuild"
+
+  exec env \
+    BASH_500_PREFIX="$BASH_500_PREFIX" \
+    __BASH500_CLEANUP=1 \
+    PATH="$BASH_500_PREFIX/bin:$PATH" \
+    "$BASH_500_PREFIX/bin/bash" "$0" "$@"
+fi
+
+if [ -n "${__BASH500_CLEANUP:-}" ]; then
+  trap 'rm -rf -- "$BASH_500_PREFIX" >/dev/null 2>&1 || true' EXIT
+  export PATH="$BASH_500_PREFIX/bin:$PATH"
+fi
+
 cd cvc4
 export MACHINE_TYPE=x86_64
-if [ ${ARCH_BASE} != 'windows' ]; then
+if [ "${ARCH_BASE}" != 'windows' ]; then
     sed -i -re 's,rm -rf src/antlr3debughandlers.c \&\& touch src/antlr3debughandlers.c,rm -rf src/antlr3debughandlers.c \&\& touch src/antlr3debughandlers.c \&\& cp  /usr/share/misc/config.* . ,g' ./contrib/get-antlr-3.4
 else
     sed -i 's,#!/usr/bin/env bash,#!/usr/bin/env bash\nshopt -u patsub_replacement,g' src/expr/mkmetakind
     sed -i 's,#include <iosfwd>,#include <iosfwd>\n#include <cstdint>,g' src/expr/metakind_template.h
-    sed -i 's,#include <string>,#include <string>\n#include <cstdint>,g' src/api/cvc4cpp.h 
+    sed -i 's,#include <string>,#include <string>\n#include <cstdint>,g' src/api/cvc4cpp.h
 fi
-ANTLR_CONFIGURE_ARGS="--host=${CROSS_NAME} --build=`gcc -dumpmachine`"  ./contrib/get-antlr-3.4
+
+ANTLR_CONFIGURE_ARGS="--host=${CROSS_NAME} --build=$(gcc -dumpmachine)" ./contrib/get-antlr-3.4
+
 git clone https://github.com/uiri/toml.git
-export PYTHONPATH=$PYTHONPATH:`pwd`/toml
-if [ ${ARCH_BASE} == 'windows' ]; then
-    export CMAKE_TOOLCHAIN_FILE=${PATCHES_DIR}/Toolchain-mingw64.cmake
+export PYTHONPATH="$PYTHONPATH:$(pwd)/toml"
+
+if [ "${ARCH_BASE}" = 'windows' ]; then
+    export CMAKE_TOOLCHAIN_FILE="${PATCHES_DIR}/Toolchain-mingw64.cmake"
     sed -i -re 's,cmake \"\$root_dir\" \$cmake_opts,cmake \"\$root_dir\" \$cmake_opts -DCMAKE_TOOLCHAIN_FILE=\$\{CMAKE_TOOLCHAIN_FILE\} -DCVC4_WINDOWS_BUILD=TRUE,g' configure.sh
 else
     sed -i -re 's,cmake \"\$root_dir\" \$cmake_opts,cmake \"\$root_dir\" \$cmake_opts -DCMAKE_TOOLCHAIN_FILE=\$\{CMAKE_TOOLCHAIN_FILE\},g' configure.sh
 fi
-CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure.sh --static --no-static-binary --prefix=${INSTALL_PREFIX} --no-unit-testing
+
+CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure.sh --static --no-static-binary --prefix="${INSTALL_PREFIX}" --no-unit-testing
 cd build
-make DESTDIR=${OUTPUT_DIR} -j${NPROC}
-make DESTDIR=${OUTPUT_DIR} install
+make "DESTDIR=${OUTPUT_DIR}" -j"${NPROC}"
+make "DESTDIR=${OUTPUT_DIR}" install
 cd ..
-mkdir -p ${OUTPUT_DIR}/dev
-mkdir -p ${OUTPUT_DIR}/dev/build
-cp -r src ${OUTPUT_DIR}/dev/.
-cp -r build/src ${OUTPUT_DIR}/dev/build/.
-rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/include
-rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/lib
+mkdir -p "${OUTPUT_DIR}/dev" "${OUTPUT_DIR}/dev/build"
+cp -r src "${OUTPUT_DIR}/dev/."
+cp -r build/src "${OUTPUT_DIR}/dev/build/."
+rm -rf "${OUTPUT_DIR}${INSTALL_PREFIX}/include"
+rm -rf "${OUTPUT_DIR}${INSTALL_PREFIX}/lib"

--- a/default/scripts/cvc4.sh
+++ b/default/scripts/cvc4.sh
@@ -1,47 +1,7 @@
-if [ -z "$__BASH500_BOOTSTRAPPED" ]; then
-  set -eu
-
-  export __BASH500_BOOTSTRAPPED=1
-  : "${BASH_500_PREFIX:="$(mktemp -d /tmp/bash-5.0.XXXXXXXX)"}"
-  : "${BASH_500_VERSION:=5.0}"
-  : "${BASH_500_TARBALL:=bash-${BASH_500_VERSION}.tar.gz}"
-  : "${BASH_500_URL:=https://ftp.gnu.org/gnu/bash/${BASH_500_TARBALL}}"
-
-  if command -v apt-get >/dev/null 2>&1 && [ "$(id -u)" -eq 0 ]; then
-    apt-get update -y >/dev/null 2>&1 || true
-    apt-get install -y build-essential wget curl libncurses-dev >/dev/null 2>&1 || true
-  fi
-
-  tmpbuild="$(mktemp -d /tmp/bash-5.0-src.XXXXXXXX)"
-  (
-    set -e
-    cd "$tmpbuild"
-    if command -v wget >/dev/null 2>&1; then
-      wget -q "$BASH_500_URL"
-    else
-      curl -fsSL -o "$BASH_500_TARBALL" "$BASH_500_URL"
-    fi
-    tar xzf "$BASH_500_TARBALL"
-    cd "bash-${BASH_500_VERSION}"
-    ./configure --prefix="$BASH_500_PREFIX" >/dev/null
-    make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)" >/dev/null
-    make install >/dev/null
-  )
-  rm -rf "$tmpbuild"
-
-  exec env \
-    BASH_500_PREFIX="$BASH_500_PREFIX" \
-    __BASH500_CLEANUP=1 \
-    PATH="$BASH_500_PREFIX/bin:$PATH" \
-    "$BASH_500_PREFIX/bin/bash" "$0" "$@"
-fi
-
-if [ -n "${__BASH500_CLEANUP:-}" ]; then
-  trap 'rm -rf -- "$BASH_500_PREFIX" >/dev/null 2>&1 || true' EXIT
-  export PATH="$BASH_500_PREFIX/bin:$PATH"
-fi
-
 cd cvc4
+for f in src/expr/mkexpr src/expr/mkkind src/expr/mkmetakind; do
+    sed -i '1a shopt -u patsub_replacement' "$f"
+done
 export MACHINE_TYPE=x86_64
 if [ "${ARCH_BASE}" != 'windows' ]; then
     sed -i -re 's,rm -rf src/antlr3debughandlers.c \&\& touch src/antlr3debughandlers.c,rm -rf src/antlr3debughandlers.c \&\& touch src/antlr3debughandlers.c \&\& cp  /usr/share/misc/config.* . ,g' ./contrib/get-antlr-3.4

--- a/default/scripts/cvc5.sh
+++ b/default/scripts/cvc5.sh
@@ -32,7 +32,8 @@ mkdir -p ${OUTPUT_DIR}/dev
 mkdir -p ${OUTPUT_DIR}/dev/build/deps/lib
 cp -r src ${OUTPUT_DIR}/dev/.
 cp -r build/src ${OUTPUT_DIR}/dev/build/.
-rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/include
+cp -r ${OUTPUT_DIR}${INSTALL_PREFIX}/include ${OUTPUT_DIR}/dev/build/include
 rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/lib
+rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/include
 cp -r ${BUILD_DIR}/libpoly/yosyshq/lib/*.a ${OUTPUT_DIR}/dev/build/deps/lib/.
 cp -r ${BUILD_DIR}/cadical/yosyshq/lib/*.a ${OUTPUT_DIR}/dev/build/deps/lib/.

--- a/default/scripts/graphviz.sh
+++ b/default/scripts/graphviz.sh
@@ -32,6 +32,7 @@ pushd lib/ortho && make && popd
 pushd lib/gvc && make && popd
 
 pushd plugin/core && make && popd
+pushd plugin/webp && make && popd
 pushd lib/neatogen && make && popd
 pushd lib/twopigen && make && popd
 pushd lib/patchwork && make && popd
@@ -48,5 +49,5 @@ pushd plugin/pango && make && popd
 pushd cmd/dot && make dot_static${EXE} && popd
 
 mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}/bin
+find . -name "dot_static"
 cp cmd/dot/dot_static${EXE} ${OUTPUT_DIR}${INSTALL_PREFIX}/bin/dot${EXE}
-

--- a/default/scripts/imctk.sh
+++ b/default/scripts/imctk.sh
@@ -2,4 +2,4 @@ cd imctk
 rm -rf abc-sys/codegen.sh
 sed -i 's,debug = true,#debug = true,g' Cargo.toml
 sed -i 's,pub const l_False,//pub const l_False,g' abc-sys/src/generated/bindings.rs
-cargo install --no-track --path eqy-engine --root ${OUTPUT_DIR}${INSTALL_PREFIX} --target=${CARGO_TARGET}
+RUSTFLAGS="-A dangerous-implicit-autorefs" cargo install --no-track --path eqy-engine --root ${OUTPUT_DIR}${INSTALL_PREFIX} --target=${CARGO_TARGET}

--- a/default/scripts/pono.sh
+++ b/default/scripts/pono.sh
@@ -1,9 +1,11 @@
 mkdir -p pono/deps/smt-switch/local
 mkdir -p pono/deps/btor2tools/build/lib
+mkdir -p pono/deps/bitwuzla
 cp -R ${BUILD_DIR}/smt-switch${INSTALL_PREFIX}/* pono/deps/smt-switch/local/.
 cp -R ${BUILD_DIR}/boolector/dev/deps/btor2tools/src pono/deps/btor2tools/.
 cp -R pono/deps/smt-switch/local/cmake pono/deps/smt-switch/.
-cp boolector/dev/deps/btor2tools/build/libbtor2parser.a pono/deps/btor2tools/build/lib/.
+cp -R ${BUILD_DIR}/bitwuzla/dev/lib/x86_64-linux-gnu/* pono/deps/bitwuzla/.
+cp boolector/dev/deps/btor2tools/build/lib/libbtor2parser.a pono/deps/btor2tools/build/lib/.
 cp boolector/dev/deps/lingeling/build/liblgl.a pono/deps/smt-switch/local/lib/.
 cp boolector/dev/deps/cadical/build/libcadical.a pono/deps/smt-switch/local/lib/.
 cd pono
@@ -17,7 +19,10 @@ if [ ${ARCH_BASE} == 'windows' ]; then
     sed -i -re 's,FMT_USE_WINDOWS_H 1,FMT_USE_WINDOWS_H 0,g' contrib/fmt/format.h
     sed -i -re 's,SIGALRM,SIGABRT,g' pono.cpp
 fi
-./configure.sh --static-lib
+export LDFLAGS="-L${BUILD_DIR}/pono/deps/bitwuzla $LDFLAGS"
+export CMAKE_PREFIX_PATH="${BUILD_DIR}/pono/deps/bitwuzla:$CMAKE_PREFIX_PATH"
+export PKG_CONFIG_PATH="${BUILD_DIR}/pono/deps/bitwuzla/pkgconfig:$PKG_CONFIG_PATH"
+./configure.sh --static-lib --prefix=${INSTALL_PREFIX}
 cd build
 make -j${NPROC}
 mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}/bin

--- a/default/scripts/smt-switch.sh
+++ b/default/scripts/smt-switch.sh
@@ -17,7 +17,11 @@ if [ ${ARCH_BASE} == 'darwin' ]; then
     sed -i -re 's,darwin,linux,g' scripts/repack-static-lib.sh 
     sed -i -re 's,libtool,x86_64-apple-darwin23.5-libtool,g' scripts/repack-static-lib.sh 
 fi
-./configure.sh --cvc5 --cvc5-home=${BUILD_DIR}/cvc5/dev --btor-home=${BUILD_DIR}/boolector/dev -DCADICAL:FILEPATH=${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib --prefix=${INSTALL_PREFIX} --static --smtlib-reader
+
+mkdir -p ${BUILD_DIR}/smt-switch/deps/install/lib
+cp ${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib/libcadical.a ${BUILD_DIR}/smt-switch/deps/install/lib/libcadical.a
+
+./configure.sh --cvc5 --cvc5-home=${BUILD_DIR}/cvc5/dev --btor-home=${BUILD_DIR}/boolector/dev -DCADICAL:FILEPATH=${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib/libcadical.a --prefix=${INSTALL_PREFIX} --static --smtlib-reader
 cd build
 make DESTDIR=${OUTPUT_DIR} -j${NPROC}
 make DESTDIR=${OUTPUT_DIR} install

--- a/default/scripts/smt-switch.sh
+++ b/default/scripts/smt-switch.sh
@@ -20,8 +20,9 @@ fi
 
 mkdir -p ${BUILD_DIR}/smt-switch/deps/install/lib
 cp ${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib/libcadical.a ${BUILD_DIR}/smt-switch/deps/install/lib/libcadical.a
+cp -R ${BUILD_DIR}/bitwuzla/dev/include/* ${BUILD_DIR}/smt-switch/bitwuzla/include/
 
-./configure.sh --cvc5 --cvc5-home=${BUILD_DIR}/cvc5/dev --btor-home=${BUILD_DIR}/boolector/dev -DCADICAL:FILEPATH=${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib/libcadical.a --prefix=${INSTALL_PREFIX} --static --smtlib-reader
+./configure.sh --bitwuzla --bitwuzla-dir=${BUILD_DIR}/bitwuzla/dev --cvc5 --cvc5-home=${BUILD_DIR}/cvc5/dev --btor-home=${BUILD_DIR}/boolector/dev -DCADICAL:FILEPATH=${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib/libcadical.a --prefix=${INSTALL_PREFIX} --static --smtlib-reader
 cd build
 make DESTDIR=${OUTPUT_DIR} -j${NPROC}
 make DESTDIR=${OUTPUT_DIR} install

--- a/default/scripts/smt-switch.sh
+++ b/default/scripts/smt-switch.sh
@@ -17,7 +17,7 @@ if [ ${ARCH_BASE} == 'darwin' ]; then
     sed -i -re 's,darwin,linux,g' scripts/repack-static-lib.sh 
     sed -i -re 's,libtool,x86_64-apple-darwin23.5-libtool,g' scripts/repack-static-lib.sh 
 fi
-./configure.sh --cvc5 --cvc5-home=${BUILD_DIR}/cvc5/dev --btor-home=${BUILD_DIR}/boolector/dev --prefix=${INSTALL_PREFIX} --static --smtlib-reader
+./configure.sh --cvc5 --cvc5-home=${BUILD_DIR}/cvc5/dev --btor-home=${BUILD_DIR}/boolector/dev -DCADICAL:FILEPATH=${BUILD_DIR}/cadical${INSTALL_PREFIX}/lib --prefix=${INSTALL_PREFIX} --static --smtlib-reader
 cd build
 make DESTDIR=${OUTPUT_DIR} -j${NPROC}
 make DESTDIR=${OUTPUT_DIR} install

--- a/default/scripts/system-resources.sh
+++ b/default/scripts/system-resources.sh
@@ -8,7 +8,6 @@ if [ ${ARCH_BASE} == 'linux' ]; then
     mkdir -p ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/dri
 if [ ${ARCH} == 'linux-x64' ]; then
     cp /usr/lib/${CROSS_NAME}/dri/crocus_dri.so ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/dri/.
-    cp /usr/lib/${CROSS_NAME}/dri/i965_dri.so ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/dri/.
     pushd ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/dri
     ln -s crocus_dri.so d3d12_dri.so
     ln -s crocus_dri.so i915_dri.so
@@ -22,6 +21,7 @@ if [ ${ARCH} == 'linux-x64' ]; then
     ln -s crocus_dri.so virtio_gpu_dri.so
     ln -s crocus_dri.so vmwgfx_dri.so
     ln -s crocus_dri.so zink_dri.so 
+    ln -s crocus_dri.so i965_dri.so # crocus now handles i965_dri (ubuntu 24.04)
     ln -s i965_dri.so nouveau_vieux_dri.so
     ln -s i965_dri.so r200_dri.so
     ln -s i965_dri.so radeon_dri.so 

--- a/docker/cross-base/Dockerfile
+++ b/docker/cross-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/cross-base/Dockerfile
+++ b/docker/cross-base/Dockerfile
@@ -15,6 +15,7 @@ RUN set -e -x ;\
         git \
         pkg-config \
         python3 \
+        python3-venv \
         adwaita-icon-theme-full \
         cmake \
         wget \

--- a/docker/cross-base/build.sh
+++ b/docker/cross-base/build.sh
@@ -1,1 +1,1 @@
-docker build -t="yosyshq/cross-base:2.0" .
+docker build -t="yosyshq/cross-base:3.0" .

--- a/docker/cross-darwin-arm64/Dockerfile
+++ b/docker/cross-darwin-arm64/Dockerfile
@@ -9,7 +9,7 @@ RUN cd /tmp \
     && sed -i "s,CXXFLAGS=-O2 -std=c++11,CXXFLAGS=-O2 -std=c++11 -static-libstdc++ -static-libgcc,g" Makefile \
     && make 
 
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 RUN set -e -x ;\
     apt -y update ;\

--- a/docker/cross-darwin-arm64/Dockerfile.22
+++ b/docker/cross-darwin-arm64/Dockerfile.22
@@ -9,7 +9,7 @@ RUN cd /tmp \
     && sed -i "s,CXXFLAGS=-O2 -std=c++11,CXXFLAGS=-O2 -std=c++11 -static-libstdc++ -static-libgcc,g" Makefile \
     && make 
 
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 RUN set -e -x ;\
     apt -y update ;\

--- a/docker/cross-darwin-x64/Dockerfile
+++ b/docker/cross-darwin-x64/Dockerfile
@@ -9,7 +9,7 @@ RUN cd /tmp \
     && sed -i "s,CXXFLAGS=-O2 -std=c++11,CXXFLAGS=-O2 -std=c++11 -static-libstdc++ -static-libgcc,g" Makefile \
     && make 
 
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 RUN set -e -x ;\
     apt -y update ;\

--- a/docker/cross-darwin-x64/Dockerfile.22
+++ b/docker/cross-darwin-x64/Dockerfile.22
@@ -9,7 +9,7 @@ RUN cd /tmp \
     && sed -i "s,CXXFLAGS=-O2 -std=c++11,CXXFLAGS=-O2 -std=c++11 -static-libstdc++ -static-libgcc,g" Makefile \
     && make 
 
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 RUN set -e -x ;\
     apt -y update ;\

--- a/docker/cross-darwin-x64/Dockerfile.22
+++ b/docker/cross-darwin-x64/Dockerfile.22
@@ -303,11 +303,3 @@ COPY gschemas.compiled /opt/local/share/glib-2.0/schemas/
 RUN RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo rustup toolchain install nightly
 RUN RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo rustup override set nightly
 RUN RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo rustup target add x86_64-apple-darwin
-
-RUN apt purge --auto-remove cmake -y ;\
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null ;\
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null ;\
-    apt-get update -y ;\
-    apt-get install cmake -y;\
-    apt -y autoremove ;\
-    rm -rf /var/lib/apt/lists/*

--- a/docker/cross-darwin-x64/build.sh
+++ b/docker/cross-darwin-x64/build.sh
@@ -1,1 +1,1 @@
-docker build -t="yosyshq/cross-darwin-x64:2.2" -f Dockerfile.22 .
+docker build -t="yosyshq/cross-darwin-x64:3.0" -f Dockerfile.22 .

--- a/docker/cross-linux-arm64/Dockerfile
+++ b/docker/cross-linux-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 ENV CROSS_NAME aarch64-linux-gnu
 

--- a/docker/cross-linux-arm64/build.sh
+++ b/docker/cross-linux-arm64/build.sh
@@ -1,1 +1,1 @@
-docker build -t="yosyshq/cross-linux-arm64:2.2" -f Dockerfile.22 .
+docker build -t="yosyshq/cross-linux-arm64:3.0" -f Dockerfile.22 .

--- a/docker/cross-linux-x64/Dockerfile
+++ b/docker/cross-linux-x64/Dockerfile
@@ -1,4 +1,4 @@
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 ENV CROSS_NAME x86_64-linux-gnu
 

--- a/docker/cross-linux-x64/Dockerfile.22
+++ b/docker/cross-linux-x64/Dockerfile.22
@@ -66,11 +66,3 @@ RUN ln -s /lib64/ld-linux-x86-64.so.2 /lib64/ld-lsb-x86-64.so.3
 
 RUN RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo rustup toolchain install nightly
 RUN RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo rustup override set nightly
-
-RUN apt purge --auto-remove cmake -y ;\
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null ;\
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null ;\
-    apt-get update -y ;\
-    apt-get install cmake -y;\
-    apt -y autoremove ;\
-    rm -rf /var/lib/apt/lists/*

--- a/docker/cross-linux-x64/Dockerfile.22
+++ b/docker/cross-linux-x64/Dockerfile.22
@@ -1,4 +1,4 @@
-FROM yosyshq/cross-base:2.0
+FROM yosyshq/cross-base:3.0
 
 ENV CROSS_NAME x86_64-linux-gnu
 

--- a/docker/cross-linux-x64/build.sh
+++ b/docker/cross-linux-x64/build.sh
@@ -1,1 +1,1 @@
-docker build -t="yosyshq/cross-linux-x64:2.2" -f Dockerfile.22 .
+docker build -t="yosyshq/cross-linux-x64:3.0" -f Dockerfile.22 .

--- a/docker/cross-windows-x64/build.sh
+++ b/docker/cross-windows-x64/build.sh
@@ -1,1 +1,1 @@
-docker build -t="yosyshq/cross-windows-x64:2.2" -f Dockerfile.22 .
+docker build -t="yosyshq/cross-windows-x64:3.0" -f Dockerfile.22 .

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -32,7 +32,10 @@ for bindir in bin py2bin py3bin super_prove/bin share/verilator/bin lib/ivl; do
     for binfile in $(file $bindir/* | grep ELF | grep dynamically | grep interpreter | cut -f1 -d:); do
         rel_path=$(realpath --relative-to=$bindir .)
         for lib in $(lddtree -l $binfile | tail -n +2 | grep ^/ ); do
-            cp -i "${lib}" lib/
+            dst="lib/$(basename "$lib")"
+            if [[ ! "$lib" -ef "$dst" ]]; then
+                cp "${lib}" lib/
+            fi
         done
         mv $binfile libexec
         is_using_fonts=false
@@ -255,7 +258,10 @@ done
 for libdir in lib; do
     for libfile in $(find $libdir -type f | xargs file | grep ELF | grep dynamically | cut -f1 -d:); do
         for lib in $(lddtree -l $libfile | tail -n +2 | grep ^/ ); do
-            cp -i "${lib}" lib/
+            dst="lib/$(basename "$lib")"
+            if [[ ! "$lib" -ef "$dst" ]]; then
+                cp "${lib}" lib/
+            fi
         done
     done
 done

--- a/src/base.py
+++ b/src/base.py
@@ -431,7 +431,7 @@ def executeBuild(target, arch, prefix, build_dir, output_dir, nproc, pack_source
 		else:
 			params += ['-e', '{}={}'.format(i, j)]
 	params += [
-		'yosyshq/cross-'+ arch + ':2.2',
+		'yosyshq/cross-'+ arch + ':3.0',
 		'bash', scriptfile.name
 	]
 	return run_live(params, cwd=build_dir)


### PR DESCRIPTION
Upgrades cross-base to Ubuntu 24.04, updates various packages and build scripts so that they are functional on Ubuntu 24.04.

Some reasons for these changes include:
- Ubuntu 20.04 is no longer supported by Canonical
- Compatibility with other projects such as SpinalHDL (similar issue to #181) which cannot be fixed by downgrading to 20.04

These changes have been manually tested using the cross-linux-x64 package. The changes have not been built or tested with the other cross packages. I would be happy to perform the builds on the other cross packages myself if pointed to the resources to do so.

Also, as there is no test suite I could find, I'd appreciate some guidance on any additional testing you'd like completed. I've tested this on my SpinalHDL project, and ran binaries with `-h` to confirm they can be executed.

Related Issues: #181 #168