### PR TITLE
Version pin cocotb

### DIFF
--- a/default/rules/cocotb.py
+++ b/default/rules/cocotb.py
@@ -4,7 +4,7 @@ SourceLocation(
 	name = 'cocotb',
 	vcs = 'git',
 	location = 'https://github.com/cocotb/cocotb',
-	revision = 'origin/master',
+	revision = '41564633538c4e7abbd9a397492addf35ec7c7ac',
 	license_file = 'LICENSE',
 )
 


### PR DESCRIPTION
A recent update to cocotb causes a dual license error:
```configuration error: `project.license` must be valid exactly by one definition (2 matches found):```

Version pinning to prevent inconsistent behavior with this tool.