### PR TITLE
Unfroze GTKWave

### DIFF
--- a/default/rules/waveformviewers.py
+++ b/default/rules/waveformviewers.py
@@ -4,7 +4,7 @@ SourceLocation(
 	name = 'gtkwave',
 	vcs = 'git',
 	location = 'https://github.com/gtkwave/gtkwave',
-	revision = '10cfae614ed8be80b5bb64e8c2194e7dffcd297a',
+	revision = 'origin/master',
 	license_file = 'LICENSE',
 )
 
@@ -12,6 +12,7 @@ Target(
 	name = 'gtkwave',
 	sources = [ 'gtkwave' ],
 	package = 'gtkwave',
+	arch = [ 'linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64', 'windows-x64' ],
 )
 
 SourceLocation(

--- a/default/scripts/gtkwave.sh
+++ b/default/scripts/gtkwave.sh
@@ -1,18 +1,43 @@
-if [ ${ARCH_BASE} == 'darwin' ]; then
-    cd gtkwave/gtkwave3-gtk3
-    sed -i -re "s,@GSETTINGS_RULES@,,g" ./src/Makefile.am
-    ./autogen.sh
-    ./configure --prefix=${INSTALL_PREFIX} --host=${CROSS_NAME} --enable-gtk3 --with-tcl=$(xcrun --show-sdk-path)/System/Library/Frameworks/Tcl.framework --with-tk=$(xcrun --show-sdk-path)/System/Library/Frameworks/Tk.framework --disable-dependency-tracking
-elif [ ${ARCH_BASE} == 'windows' ]; then
-    cd gtkwave/gtkwave3-gtk3
-    sed -i -re "s,@GSETTINGS_RULES@,,g" ./src/Makefile.am
-    ./autogen.sh
-    ./configure --prefix=${INSTALL_PREFIX} --host=${CROSS_NAME} --enable-gtk3 MINGW_LDADD="-lcomdlg32" --with-tcl=/usr/x86_64-w64-mingw32/sys-root/mingw/lib --with-tk=/usr/x86_64-w64-mingw32/sys-root/mingw/lib
-else
-    cd gtkwave/gtkwave3-gtk3
-    ./autogen.sh
-    ./configure --prefix=${INSTALL_PREFIX} --host=${CROSS_NAME} --enable-gtk3
+cd gtkwave
+
+# Setup meson and ninja (not available in Docker image)
+if ! command -v meson &>/dev/null; then
+    wget -q https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip -O /tmp/ninja.zip
+    python3 -c "import zipfile; zipfile.ZipFile('/tmp/ninja.zip').extractall('/tmp/meson-tools')"
+    chmod +x /tmp/meson-tools/ninja
+    wget -q https://github.com/mesonbuild/meson/releases/download/1.7.0/meson-1.7.0.tar.gz -O /tmp/meson.tar.gz
+    tar xf /tmp/meson.tar.gz -C /tmp/meson-tools
+    printf '#!/bin/sh\nexec python3 /tmp/meson-tools/meson-1.7.0/meson.py "$@"\n' > /tmp/meson-tools/meson
+    chmod +x /tmp/meson-tools/meson
+    export PATH=/tmp/meson-tools:$PATH
 fi
-make DESTDIR=${OUTPUT_DIR} UPDATE_DESKTOP_DATABASE=/bin/true -j${NPROC} install
-rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/gtkwave 
-rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/gtkwave-gtk3 
+
+if [ ${ARCH} != 'linux-x64' ]; then
+    case ${ARCH} in
+        linux-arm64)  SYSTEM=linux;   CPU=aarch64 ;;
+        darwin-x64)   SYSTEM=darwin;  CPU=x86_64 ;;
+        darwin-arm64) SYSTEM=darwin;  CPU=aarch64 ;;
+        windows-x64)  SYSTEM=windows; CPU=x86_64 ;;
+    esac
+    cat > cross.ini <<CROSS_EOF
+[binaries]
+c = '${CC}'
+cpp = '${CXX}'
+ar = '${AR}'
+strip = '${STRIP}'
+pkgconfig = 'pkg-config'
+
+[host_machine]
+system = '${SYSTEM}'
+cpu_family = '${CPU}'
+cpu = '${CPU}'
+endian = 'little'
+CROSS_EOF
+    CROSS_ARG="--cross-file cross.ini"
+fi
+
+meson setup builddir --prefix=${INSTALL_PREFIX} --libdir=lib -Dupdate_mime_database=false -Dintrospection=false -Dset_rpath=disabled ${CROSS_ARG}
+ninja -C builddir -j${NPROC}
+DESTDIR=${OUTPUT_DIR} ninja -C builddir install
+rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/gtkwave
+rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/share/gtkwave3

--- a/docker/cross-darwin-arm64/Dockerfile.22
+++ b/docker/cross-darwin-arm64/Dockerfile.22
@@ -266,6 +266,27 @@ RUN cd /opt \
   && ln -s /opt/local /usr/local/osxcross/target/macports/pkgs/opt \
   && cp /opt/local/lib/pkgconfig/gtk-mac-integration-gtk3.pc /opt/local/lib/pkgconfig/gtk-mac-integration.pc
 
+# Additional packages for gtkwave (GTK4 + json-glib)
+RUN cd /tmp \
+  && wget https://packages.macports.org/json-glib/json-glib-1.10.8_0.darwin_21.arm64.tbz2 \
+  && tar xfj json-glib-1.10.8_0.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/graphene/graphene-1.10.8_1.darwin_21.arm64.tbz2 \
+  && tar xfj graphene-1.10.8_1.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/gtk4/gtk4-4.14.3_0+x11.darwin_21.arm64.tbz2 \
+  && tar xfj gtk4-4.14.3_0+x11.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXi/xorg-libXi-1.8.2_0.darwin_21.arm64.tbz2 \
+  && tar xfj xorg-libXi-1.8.2_0.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXrandr/xorg-libXrandr-1.5.4_0.darwin_21.arm64.tbz2 \
+  && tar xfj xorg-libXrandr-1.5.4_0.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXcursor/xorg-libXcursor-1.2.3_0.darwin_21.arm64.tbz2 \
+  && tar xfj xorg-libXcursor-1.2.3_0.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXinerama/xorg-libXinerama-1.1.5_0.darwin_21.arm64.tbz2 \
+  && tar xfj xorg-libXinerama-1.1.5_0.darwin_21.arm64.tbz2 \
+  && wget https://packages.macports.org/xrender/xrender-0.9.12_0.darwin_21.arm64.tbz2 \
+  && tar xfj xrender-0.9.12_0.darwin_21.arm64.tbz2 \
+  && cp /opt/local/share/pkgconfig/* /opt/local/lib/pkgconfig/. 2>/dev/null || true \
+  && rm -rf /tmp/*
+
 COPY --from=builder /tmp/macdylibbundler/dylibbundler /usr/local/bin/dylibbundler
 COPY --from=builder /root/.cargo/bin/rcodesign /usr/local/bin/rcodesign
 RUN chmod +x /usr/local/bin/dylibbundler

--- a/docker/cross-darwin-x64/Dockerfile.22
+++ b/docker/cross-darwin-x64/Dockerfile.22
@@ -266,6 +266,27 @@ RUN cd /opt \
   && ln -s /opt/local /usr/local/osxcross/target/macports/pkgs/opt \
   && cp /opt/local/lib/pkgconfig/gtk-mac-integration-gtk3.pc /opt/local/lib/pkgconfig/gtk-mac-integration.pc
 
+# Additional packages for gtkwave (GTK4 + json-glib)
+RUN cd /tmp \
+  && wget https://packages.macports.org/json-glib/json-glib-1.10.8_0.darwin_21.x86_64.tbz2 \
+  && tar xfj json-glib-1.10.8_0.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/graphene/graphene-1.10.8_1.darwin_21.x86_64.tbz2 \
+  && tar xfj graphene-1.10.8_1.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/gtk4/gtk4-4.14.3_0+x11.darwin_21.x86_64.tbz2 \
+  && tar xfj gtk4-4.14.3_0+x11.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXi/xorg-libXi-1.8.2_0.darwin_21.x86_64.tbz2 \
+  && tar xfj xorg-libXi-1.8.2_0.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXrandr/xorg-libXrandr-1.5.4_0.darwin_21.x86_64.tbz2 \
+  && tar xfj xorg-libXrandr-1.5.4_0.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXcursor/xorg-libXcursor-1.2.3_0.darwin_21.x86_64.tbz2 \
+  && tar xfj xorg-libXcursor-1.2.3_0.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/xorg-libXinerama/xorg-libXinerama-1.1.5_0.darwin_21.x86_64.tbz2 \
+  && tar xfj xorg-libXinerama-1.1.5_0.darwin_21.x86_64.tbz2 \
+  && wget https://packages.macports.org/xrender/xrender-0.9.12_0.darwin_21.x86_64.tbz2 \
+  && tar xfj xrender-0.9.12_0.darwin_21.x86_64.tbz2 \
+  && cp /opt/local/share/pkgconfig/* /opt/local/lib/pkgconfig/. 2>/dev/null || true \
+  && rm -rf /tmp/*
+
 COPY --from=builder /tmp/macdylibbundler/dylibbundler /usr/local/bin/dylibbundler
 COPY --from=builder /root/.cargo/bin/rcodesign /usr/local/bin/rcodesign
 RUN chmod +x /usr/local/bin/dylibbundler

--- a/docker/cross-linux-arm64/Dockerfile
+++ b/docker/cross-linux-arm64/Dockerfile
@@ -32,6 +32,9 @@ RUN set -e -x ;\
         libftdi1-dev:arm64 \
         libgmp-dev:arm64 \
         libgtk-3-dev:arm64 \
+        libgtk-4-dev:arm64 \
+        libjson-glib-dev:arm64 \
+        desktop-file-utils \
         liblzma-dev:arm64 \
         libreadline-dev:arm64 \
         libsqlite3-dev:arm64 \

--- a/docker/cross-linux-x64/Dockerfile
+++ b/docker/cross-linux-x64/Dockerfile
@@ -23,6 +23,9 @@ RUN set -e -x ;\
         libftdi1-dev \
         libgmp-dev \
         libgtk-3-dev \
+        libgtk-4-dev \
+        libjson-glib-dev \
+        desktop-file-utils \
         liblzma-dev \
         libreadline-dev \
         libsqlite3-dev \

--- a/docker/cross-linux-x64/Dockerfile.22
+++ b/docker/cross-linux-x64/Dockerfile.22
@@ -26,6 +26,9 @@ RUN set -e -x ;\
         libftdi1-dev \
         libgmp-dev \
         libgtk-3-dev \
+        libgtk-4-dev \
+        libjson-glib-dev \
+        desktop-file-utils \
         liblzma-dev \
         libreadline-dev \
         libsqlite3-dev \

--- a/docker/cross-windows-x64/Dockerfile
+++ b/docker/cross-windows-x64/Dockerfile
@@ -10,6 +10,8 @@ RUN dnf install -y  mingw64-gcc \
                     mingw64-tk \
                     mingw64-xz \
                     mingw64-gtk3 \
+                    mingw64-gtk4 \
+                    mingw64-json-glib \
                     mingw64-qt5-qtbase \
                     mingw64-eigen3 \
                     mingw64-dlfcn \


### PR DESCRIPTION
Fixes https://github.com/YosysHQ/oss-cad-suite-build/issues/126

Hello! Gtkwave and the FST spec have received important updates recently.

* https://github.com/verilator/verilator/pull/7255
* https://github.com/gtkwave/libfst/issues/17

It would be really nice if this project could release the updated version of Gtkwave, instead of a random commit from 3 years ago. I know you rarely merge in other people's PRs, but I would really appreciate if we could get Gtkwave unfrozen :)

## Summary of Changes

- Updated gtkwave from https://github.com/gtkwave/gtkwave/commit/10cfae6 (~3 years old) to `origin/master`
- Rewrote build script for gtkwave's new meson build system (autotools was removed upstream)
- Add new dependencies to Docker images: `libgtk-4-dev`, `libjson-glib-dev`, `desktop-file-utils`, `graphene` (gtkwave now requires both GTK3 and GTK4)

## Gtkwave Changes in last 3 years

- Migrated from autotools to meson (>= 1.0.0)
- Source moved from `gtkwave3-gtk3/` subdirectory to repo root
- Now requires GTK4 (for `rtlbrowse`), json-glib, and external libfst (via meson wrap)
- TCL/TK dependency removed

## Docker image changes required

**CI will fail until Docker images are rebuilt.** ([runs](https://github.com/sifferman/oss-cad-suite-build/actions?query=branch%3Aunfreeze-gtkwave)) The following images need updating:

- `cross-linux-x64`: added `libgtk-4-dev`, `libjson-glib-dev`, `desktop-file-utils`
- `cross-linux-arm64`: same (`:arm64` variants)
- `cross-windows-x64`: added `mingw64-gtk4`, `mingw64-json-glib`
- `cross-darwin-x64` / `cross-darwin-arm64`: added GTK4+x11, json-glib, graphene from `packages.macports.org`

## Verification

- I have built and ran `gtkwave` successfully on linux-x64 with locally rebuilt Docker image