### PR TITLE
fix: Show the last fish command's exit code if failed

### DIFF
--- a/default/patches/environment.fish
+++ b/default/patches/environment.fish
@@ -50,11 +50,17 @@ if set --query PYTHONHOME
     set --erase PYTHONHOME
 end
 
+function _restore_status
+    return $argv[1]
+end
+
 functions --copy fish_prompt _old_environment_fish_prompt
 function fish_prompt -d "Write out the prompt"
+    set -l last_status $status
     set_color magenta
     echo -n -s '(' $VIRTUAL_ENV_PROMPT ') '
     set_color normal
+    _restore_status $last_status
     _old_environment_fish_prompt
 end
 


### PR DESCRIPTION
Partially fixes #200.

An edge-case that's still missing is showing the status of piped commands. Will submit this as-is though. 

An example of what's still missing (contrived example that no one would actually run): `echo hello_world | curl not_real_domain.com`. Fish shell naturally shows the exit code in the prompt like ` [0|6]>`
