### PR TITLE
Make ci config generator emit `--rules` into builder commands

### DIFF
--- a/builder.py
+++ b/builder.py
@@ -71,9 +71,9 @@ def ci(target, arch, rules, all):
 	validateArch(arch)
 	if all:
 		for val in architectures:
-			generateYaml("default", val, all)
+			generateYaml("default", val, all, rules)
 	else:
-		generateYaml(target, arch, all)
+		generateYaml(target, arch, all, rules)
 	
 if __name__ == '__main__':
 	if os.name == "posix":

--- a/src/base.py
+++ b/src/base.py
@@ -714,7 +714,7 @@ def buildCode(build_target, build_arch, nproc, force, dry, pack_sources, single,
 			if os.path.exists(build_dir):
 				shutil.rmtree(build_dir, onerror=removeError)
 
-def generateYaml(target, build_arch, write_to_file):
+def generateYaml(target, build_arch, write_to_file, rules):
 	log_info_triple("Creating yml for ", target, " [ {} ] architecture ...".format(build_arch))
 
 	build_order = createBuildOrder(target, build_arch, getArchitecture(), True)
@@ -803,7 +803,7 @@ def generateYaml(target, build_arch, write_to_file):
 				yaml_content +="        run: wget -qO- \"{}-{}/{}.tgz\" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -\n".format(BUCKET_URL, "linux-x64", n)
 		if target.top_package:
 			yaml_content +="      - name: Build\n"
-			yaml_content +="        run: ./builder.py build --arch={} --target={} --single\n".format(arch, target.name)
+			yaml_content +="        run: ./builder.py build --arch={} --target={} --rules={} --single\n".format(arch, target.name, rules)
 			yaml_content +="      - uses: ncipollo/release-action@v1\n"
 			yaml_content +="        if: hashFiles('_outputs/{}/{}/*.{}') != ''\n".format(arch, target.name, "exe" if arch=="windows-x64" else "tgz")
 			yaml_content +="        with:\n"
@@ -816,7 +816,7 @@ def generateYaml(target, build_arch, write_to_file):
 			yaml_content +="          token: ${{ secrets.GITHUB_TOKEN }}\n"
 		else:
 			yaml_content +="      - name: Build\n"
-			yaml_content +="        run: ./builder.py build --arch={} --target={} --single --tar\n".format(arch, target.name)
+			yaml_content +="        run: ./builder.py build --arch={} --target={} --rules={} --single --tar\n".format(arch, target.name, rules)
 			yaml_content +="      - uses: ncipollo/release-action@v1\n"
 			yaml_content +="        if: hashFiles('{}-{}.tgz') != ''\n".format(arch, target.name)
 			yaml_content +="        with:\n"


### PR DESCRIPTION
The CI config generator currently does not set the argument when calling the builder script, so when using a custom rules directory, the CI config generates fine. However, the builder script running in CI then cannot find the targets because the rules are not being loaded. This PR changes that and simply re-emits the rules argument to the `ci` subcommand into the generated yaml config.