### PR TITLE
Add NVC VHDL simulator

### DIFF
--- a/.github/workflows/linux-x64.yml
+++ b/.github/workflows/linux-x64.yml
@@ -1750,6 +1750,37 @@ jobs:
           tag: bucket-linux-x64
           artifacts: "linux-x64-iverilog.tgz"
           token: ${{ secrets.GITHUB_TOKEN }}
+  linux-x64-nvc:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - name: Cache sources
+        uses: actions/cache@v5
+        with:
+          key: cache-sources-nvc
+          path: _sources
+      - name: Download previous build
+        run: |
+          URL="https://github.com/${{ github.repository }}/releases/download/bucket-linux-x64/linux-x64-nvc.tgz"
+          if wget --spider "${URL}" 2>/dev/null; then
+              wget -qO- "${URL}" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+          else
+              echo "Previous version not found in bucket"
+          fi
+      - name: Build
+        run: ./builder.py build --arch=linux-x64 --target=nvc --rules=default --single --tar
+      - uses: ncipollo/release-action@v1
+        if: hashFiles('linux-x64-nvc.tgz') != ''
+        with:
+          allowUpdates: True
+          prerelease: True
+          omitBody: True
+          omitBodyDuringUpdate: True
+          omitNameDuringUpdate: True
+          tag: bucket-linux-x64
+          artifacts: "linux-x64-nvc.tgz"
+          token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-utils:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -1948,7 +1979,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   linux-x64-default:
     runs-on: ubuntu-latest
-    needs: [ linux-x64-aiger, linux-x64-apicula, linux-x64-avy, linux-x64-bitwuzla, linux-x64-boolector, linux-x64-cocotb, linux-x64-cvc4, linux-x64-cvc5, linux-x64-eqy, linux-x64-formal, linux-x64-ghdl, linux-x64-ghdl-yosys-plugin, linux-x64-graphviz, linux-x64-gtkwave, linux-x64-icestorm, linux-x64-imctk, linux-x64-iverilog, linux-x64-nextpnr-ecp5, linux-x64-nextpnr-generic, linux-x64-nextpnr-himbaechel, linux-x64-nextpnr-ice40, linux-x64-nextpnr-machxo2, linux-x64-nextpnr-nexus, linux-x64-openfpgaloader, linux-x64-pono, linux-x64-prjoxide, linux-x64-prjpeppercorn, linux-x64-prjtrellis, linux-x64-pyhdl, linux-x64-python2, linux-x64-python3, linux-x64-ric3, linux-x64-suprove, linux-x64-surfer, linux-x64-system-resources, linux-x64-utils, linux-x64-verilator, linux-x64-xdot, linux-x64-yices, linux-x64-yosys, linux-x64-yosys-slang-plugin, linux-x64-z3 ]
+    needs: [ linux-x64-aiger, linux-x64-apicula, linux-x64-avy, linux-x64-bitwuzla, linux-x64-boolector, linux-x64-cocotb, linux-x64-cvc4, linux-x64-cvc5, linux-x64-eqy, linux-x64-formal, linux-x64-ghdl, linux-x64-ghdl-yosys-plugin, linux-x64-graphviz, linux-x64-gtkwave, linux-x64-icestorm, linux-x64-imctk, linux-x64-iverilog, linux-x64-nextpnr-ecp5, linux-x64-nextpnr-generic, linux-x64-nextpnr-himbaechel, linux-x64-nextpnr-ice40, linux-x64-nextpnr-machxo2, linux-x64-nextpnr-nexus, linux-x64-nvc, linux-x64-openfpgaloader, linux-x64-pono, linux-x64-prjoxide, linux-x64-prjpeppercorn, linux-x64-prjtrellis, linux-x64-pyhdl, linux-x64-python2, linux-x64-python3, linux-x64-ric3, linux-x64-suprove, linux-x64-surfer, linux-x64-system-resources, linux-x64-utils, linux-x64-verilator, linux-x64-xdot, linux-x64-yices, linux-x64-yosys, linux-x64-yosys-slang-plugin, linux-x64-z3 ]
     steps:
       - name: Get current date
         id: date
@@ -2000,6 +2031,8 @@ jobs:
         run: wget -qO- "https://github.com/${{ github.repository }}/releases/download/bucket-linux-x64/linux-x64-nextpnr-machxo2.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-nextpnr-nexus
         run: wget -qO- "https://github.com/${{ github.repository }}/releases/download/bucket-linux-x64/linux-x64-nextpnr-nexus.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
+      - name: Download linux-x64-nvc
+        run: wget -qO- "https://github.com/${{ github.repository }}/releases/download/bucket-linux-x64/linux-x64-nvc.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-openfpgaloader
         run: wget -qO- "https://github.com/${{ github.repository }}/releases/download/bucket-linux-x64/linux-x64-openfpgaloader.tgz" --retry-connrefused --read-timeout=20 --timeout=15 --retry-on-http-error=404 | tar xvfz -
       - name: Download linux-x64-pono

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Contact us at contact@yosyshq.com to arrange a free evaluation license.
  * [Surfer](https://gitlab.com/surfer-project/surfer) A waveform viewer with a focus on a snappy usable interface, and extensibility.
  * [verilator](https://github.com/verilator/verilator) Verilog/SystemVerilog simulator
  * [iverilog](https://github.com/steveicarus/iverilog) Verilog compilation system
+ * [NVC](https://github.com/nickg/nvc) VHDL simulator (linux-x64 platform only)
  * [cocotb](https://github.com/cocotb/cocotb) coroutine based cosimulation library for writing VHDL and Verilog testbenches in Python
    
 ### Support libraries

--- a/default/rules/default.py
+++ b/default/rules/default.py
@@ -37,6 +37,7 @@ Target(
         'gtkwave',
         'verilator',
         'iverilog',
+        'nvc',
         'utils',
         'pyhdl',
         'cocotb',

--- a/default/rules/nvc.py
+++ b/default/rules/nvc.py
@@ -1,0 +1,15 @@
+from src.base import SourceLocation, Target
+
+SourceLocation(
+	name = 'nvc',
+	vcs = 'git',
+	location = 'https://github.com/nickg/nvc',
+	revision = 'tags/r1.22.1',
+	license_file = 'COPYING',
+)
+
+Target(
+	name = 'nvc',
+	sources = [ 'nvc' ],
+	arch = [ 'linux-x64' ],
+)

--- a/default/scripts/nvc.sh
+++ b/default/scripts/nvc.sh
@@ -1,0 +1,13 @@
+cd nvc
+./autogen.sh
+mkdir -p build
+cd build
+../configure --prefix=${INSTALL_PREFIX} --with-llvm=/usr/bin/llvm-config
+make -j${NPROC}
+make DESTDIR=${OUTPUT_DIR} install
+
+# NVC installs vendor-library install helpers under libexec/nvc. They are located via an
+# absolute compile-time path (not relocatable in the packaged suite) and their directory
+# name collides with the packaging wrapper, which moves bin/nvc to libexec/nvc. Remove them
+# so the nvc binary can be wrapped. The standard VHDL libraries (lib/nvc) are unaffected.
+rm -rf ${OUTPUT_DIR}${INSTALL_PREFIX}/libexec

--- a/docker/cross-linux-x64/Dockerfile
+++ b/docker/cross-linux-x64/Dockerfile
@@ -45,7 +45,13 @@ RUN set -e -x ;\
         libbz2-dev \
         libltdl-dev \
         libmpfr-dev \
-        libedit-dev; \
+        libedit-dev \
+        automake \
+        check \
+        llvm-dev \
+        zlib1g-dev \
+        libdw-dev \
+        libzstd-dev; \
     apt -y autoremove ;\
     rm -rf /var/lib/apt/lists/* ;\
     ln -s /lib64/ld-linux-x86-64.so.2 /lib64/ld-lsb-x86-64.so.3

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -75,6 +75,11 @@ export PYTHONEXECUTABLE="\$release_topdir_abs/bin/tabbypy3"
 export PYTHONHOME="\$release_topdir_abs"
 EOT
         fi
+        if [ "$(basename $binfile)" == "nvc" ]; then
+            cat >> $binfile << EOT
+export NVC_LIBPATH="\$release_topdir_abs/lib/nvc"
+EOT
+        fi
         if [ ! -z "$(strings libexec/$(basename $binfile) | grep ghdl)" ]; then
             cat >> $binfile << EOT
 export GHDL_PREFIX="\$release_topdir_abs/lib/ghdl"


### PR DESCRIPTION
Resolves #123 and #206.

I prepared this PR with the assistance of Claude Code (notes on that below).
I will run more tests in the next days, any suggestion is appreciated.

## Summary

Adds the [NVC](https://github.com/nickg/nvc) VHDL simulator to the suite,
built from source and pinned to release r1.22.1, and includes it in the
default `oss-cad-suite` package. Scope is linux-x64 only for this first
integration, consistent with how other VHDL tools like GHDL are scoped.
The build uses the distribution default LLVM from the cross image
(currently 21.1.8, within NVC's tested range of 8 to 21).

## Changes

Split into two commits, with the docker image change kept separate:

* `default/rules/nvc.py`: new source and target (`arch = ['linux-x64']`),
  pinned to `tags/r1.22.1`.
* `default/scripts/nvc.sh`: build recipe (`autogen.sh`, out-of-tree
  `configure --with-llvm=/usr/bin/llvm-config`, `make`, `make install`).
* `default/rules/default.py`: wires `nvc` into the `default` target.
* `README.md`: NVC entry in the Simulation/Testing tool list.
* `.github/workflows/linux-x64.yml`: regenerated with `./builder.py ci --all`.
* `scripts/package-linux.sh`: exports `NVC_LIBPATH` in the `nvc` wrapper.
* `docker/cross-linux-x64/Dockerfile` (separate commit): adds NVC's missing
  build dependencies (`automake`, `check`, `llvm-dev`, `zlib1g-dev`,
  `libdw-dev`, `libzstd-dev`).

## Notes on relocatability

Two NVC-specific issues had to be handled so the tool works in the packaged,
relocatable suite:

1. Library discovery. On Linux, NVC resolves its standard libraries via an
   absolute compile-time path (`LIBDIR`), not relative to the executable. The
   wrapper therefore exports `NVC_LIBPATH=<root>/lib/nvc` so the bundled
   STD/IEEE libraries are found after the suite is extracted to any location.

2. `libexec/nvc` collision. NVC installs vendor-install helper scripts under
   `libexec/nvc/`, whose directory name collides with the packaging wrapper
   (which moves `bin/nvc` into `libexec/nvc`). These helpers also rely on a
   non-relocatable absolute path, so they are removed in `nvc.sh`. As a
   consequence `nvc --install` is not available in the suite; core
   analyse/elaborate/run is unaffected.

## Testing

Built and verified on linux-x64 with a locally rebuilt
`yosyshq/cross-linux-x64:4.0` image:

* `nvc --version` reports `nvc 1.22.1 (Using LLVM 21.1.8)`.
* NVC's own test suite (`make check`, unit tests plus regression suite) passes
  in the cross image; TCL-related tests are skipped since TCL support is not
  enabled in this configuration.
* Analyse, elaborate and run of a small `std_logic` counter testbench succeeds
  from the staged install tree relocated to a different path, with
  `NVC_LIBPATH` pointing at the shipped libraries (same mechanism the wrapper
  uses). The full packaged suite with the generated wrapper is what I still
  want to exercise end-to-end in the coming days.

## CI / image note

The CI build pulls the published `yosyshq/cross-linux-x64` image, so the 4.0
image must be rebuilt and republished with the new packages (see the docker
commit) before CI can build NVC.

## Use of AI assistance

In the spirit of transparency: I used Claude Code to help with this work,
under my review. Concretely it helped with rebasing the branch onto the
current main after the docker 4.0 overhaul (porting the build dependencies
from the removed `Dockerfile.23` to the new image and switching from
`llvm-18-dev` to the distro `llvm-dev`), regenerating the CI workflows,
and running the build, NVC's test suite and the relocation smoke test in
the container. The relocatability analysis and the overall approach were
worked out and verified by me, and I reviewed every change before
committing.