### PR TITLE
icarus: build with --enable-libvvp so libvvp.so ships

### DIFF
--- a/default/scripts/iverilog.sh
+++ b/default/scripts/iverilog.sh
@@ -16,7 +16,7 @@ fi
 if [ ${ARCH_BASE} == 'darwin' ]; then
     export CFLAGS="-Wno-implicit-function-declaration"
 fi
-./configure --prefix=${INSTALL_PREFIX} --host=${CROSS_NAME}
+./configure --prefix=${INSTALL_PREFIX} --host=${CROSS_NAME} --enable-libvvp
 make DESTDIR=${OUTPUT_DIR} -j${NPROC} install
 sed -i -re 's|^flag:VVP_EXECUTABLE=.*$||g' ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/ivl/vvp.conf
 sed -i -re 's|^flag:VVP_EXECUTABLE=.*$||g' ${OUTPUT_DIR}${INSTALL_PREFIX}/lib/ivl/vvp-s.conf


### PR DESCRIPTION
Hello!

I was trying to do mixed-signal simulation with ngpsice+icarus, but this requires libvvp.so. This PR would enable this.

libvvp was added 2026-05-13 in https://github.com/steveicarus/iverilog/commit/9d3101fd1

Thanks!